### PR TITLE
Bump to 12.2.2, adding enable-service-access

### DIFF
--- a/bosh/opsfiles/releases.yml
+++ b/bosh/opsfiles/releases.yml
@@ -2,6 +2,6 @@
   type: replace
   value:
     name: app-autoscaler
-    version: 12.2.1
-    url: https://storage.googleapis.com/app-autoscaler-releases/releases/app-autoscaler-v12.2.1.tgz
-    sha1: sha256:39a072d429a17efd27f3b819eff29efa043dc3ffe3f0676fd7be192477ac4c71
+    version: "12.2.2"
+    url: "https://bosh.io/d/github.com/cloudfoundry-incubator/app-autoscaler-release?v=12.2.2"
+    sha1: "a1fffce71219318d1fb27ec5fc3ff84e757337ed"

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -22,6 +22,7 @@ jobs:
       trigger: true
     - get: cf-stemcell-jammy
       trigger: true
+    - get: pipeline-tasks
   - task: terraform-secrets
     file: autoscaler-manifests/ci/terraform-secrets.yml
   - put: autoscaler-deployment-development
@@ -47,6 +48,17 @@ jobs:
       vars_files:
       - autoscaler-manifests/bosh/varsfiles/development.yml
       - terraform-secrets/terraform.yml
+  - task: enable-service-access
+    file: pipeline-tasks/set-plan-visibility.yml
+    params:
+      CF_API_URL: ((cf.development.api))
+      CF_USERNAME: ((cf.development.admin_user))
+      CF_PASSWORD: ((cf.development.admin_password))
+      CF_ORGANIZATION: ((broker-organization))
+      CF_SPACE: ((broker-space))
+      BROKER_NAME: ((broker-name))
+      SERVICES: ((cf.development.services))
+      SERVICE_ORGANIZATION: ((cf.development.service_organization))
   on_success:
     put: slack
     params:
@@ -68,6 +80,7 @@ jobs:
 
 
 ## Enable these 3 to more quickly debug changes to acceptance-tests.sh, bypasses the need to first deploy autoscaler to dev
+
 #- name: acceptance-tests-broker-development-debug
 #  serial_groups: [development, debug]
 #  plan:
@@ -596,7 +609,6 @@ resources:
 - name: app-autoscaler-release
   type: git
   source:
-    commit_verification_keys: ((cloud-gov-pgp-keys))
     uri: https://github.com/cloudfoundry/app-autoscaler-release
     branch: main
     tag_filter: "v*"
@@ -611,16 +623,22 @@ resources:
     - bosh/*
 
 
-- name: autoscaler-manifests-test
+#- name: autoscaler-manifests-test
+#  type: git
+#  source:
+#    uri: https://github.com/cloud-gov/cg-deploy-autoscaler.git
+#    branch: main
+#    paths:
+#    - ci/*
+#    - bosh/*
+
+- name: pipeline-tasks
   type: git
+  icon: github-circle
   source:
-    uri: https://github.com/cloud-gov/cg-deploy-autoscaler.git
+    uri: ((pipeline-tasks-git-url))
     branch: main
-    paths:
-    - ci/*
-    - bosh/*
-
-
+    commit_verification_keys: ((cloud-gov-pgp-keys))
 
 
 - name: terraform-yaml-development


### PR DESCRIPTION
## Changes proposed in this pull request:

- Bumping to 12.2.2
- Adding enable-service-access task after deployment to enable the broker for certain orgs
- Removed `commit_verification_keys` since it isn't our repo and won't be signed by one of our staff
- Part of https://github.com/cloud-gov/product/issues/2972

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None
