### PR TITLE
Add enable-service-access to a list of orgs

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,8 @@ These contain three types of tests:
 
 In the pipeline for `cg-deploy-autoscaler`, each of these tests are configured to run after the deployment of development, staging and production as `acceptance-tests-{api,broker,app}-{development,staging,production}`.  These tests are configured to not run in parallel as each runs a `cleanup.sh` script at the end which deletes orgs with the naming convention `ASATS-*`.
 
+There is also a set of 3 acceptance tests for development debugging which are commented out, along with a custom resouce towards the bottom.  These exist to debug the bash and other scripting without having to wait for a deployment to development to finish first.  Please comment these back out before submitting PRs.
+
 
 ##  8. Manual Tests
 

--- a/bosh/opsfiles/scaling-dev.yml
+++ b/bosh/opsfiles/scaling-dev.yml
@@ -3,41 +3,41 @@
   value: 1
 - type: replace
   path: /instance_groups/name=scalingengine/vm_type
-  value: t3.medium
+  value: t3.small
 - type: replace
   path: /instance_groups/name=apiserver/instances
   value: 1
 - type: replace
   path: /instance_groups/name=apiserver/vm_type
-  value: t3.medium
+  value: t3.small
 
 - type: replace
   path: /instance_groups/name=scheduler/instances
   value: 1
 - type: replace
   path: /instance_groups/name=scheduler/vm_type
-  value: t3.medium
+  value: t3.small
 
 - type: replace
   path: /instance_groups/name=operator/instances
   value: 1
 - type: replace
   path: /instance_groups/name=operator/vm_type
-  value: t3.medium
+  value: t3.small
 
 - type: replace
   path: /instance_groups/name=eventgenerator/instances
   value: 1
 - type: replace
   path: /instance_groups/name=eventgenerator/vm_type
-  value: t3.medium
+  value: t3.small
 
 - type: replace
   path: /instance_groups/name=metricsforwarder/instances
   value: 1
 - type: replace
   path: /instance_groups/name=metricsforwarder/vm_type
-  value: t3.medium
+  value: t3.small
 
 #Misc - not worth its own ops file
 - type: remove

--- a/bosh/opsfiles/scaling-dev.yml
+++ b/bosh/opsfiles/scaling-dev.yml
@@ -3,41 +3,41 @@
   value: 1
 - type: replace
   path: /instance_groups/name=scalingengine/vm_type
-  value: t3.large
+  value: t3.medium
 - type: replace
   path: /instance_groups/name=apiserver/instances
   value: 1
 - type: replace
   path: /instance_groups/name=apiserver/vm_type
-  value: t3.large
+  value: t3.medium
 
 - type: replace
   path: /instance_groups/name=scheduler/instances
   value: 1
 - type: replace
   path: /instance_groups/name=scheduler/vm_type
-  value: t3.large
+  value: t3.medium
 
 - type: replace
   path: /instance_groups/name=operator/instances
   value: 1
 - type: replace
   path: /instance_groups/name=operator/vm_type
-  value: t3.large
+  value: t3.medium
 
 - type: replace
   path: /instance_groups/name=eventgenerator/instances
   value: 1
 - type: replace
   path: /instance_groups/name=eventgenerator/vm_type
-  value: t3.large
+  value: t3.medium
 
 - type: replace
   path: /instance_groups/name=metricsforwarder/instances
   value: 1
 - type: replace
   path: /instance_groups/name=metricsforwarder/vm_type
-  value: t3.large
+  value: t3.medium
 
 #Misc - not worth its own ops file
 - type: remove

--- a/bosh/opsfiles/scaling-prod.yml
+++ b/bosh/opsfiles/scaling-prod.yml
@@ -3,41 +3,41 @@
   value: 2
 - type: replace
   path: /instance_groups/name=scalingengine/vm_type
-  value: m5.large
+  value: t3.medium
 - type: replace
   path: /instance_groups/name=apiserver/instances
   value: 2
 - type: replace
   path: /instance_groups/name=apiserver/vm_type
-  value: m5.large
+  value: t3.medium
 
 - type: replace
   path: /instance_groups/name=scheduler/instances
   value: 2
 - type: replace
   path: /instance_groups/name=scheduler/vm_type
-  value: m5.large
+  value: t3.medium
 
 - type: replace
   path: /instance_groups/name=operator/instances
   value: 2
 - type: replace
   path: /instance_groups/name=operator/vm_type
-  value: m5.large
+  value: t3.medium
 
 - type: replace
   path: /instance_groups/name=eventgenerator/instances
   value: 2
 - type: replace
   path: /instance_groups/name=eventgenerator/vm_type
-  value: m5.large
+  value: t3.medium
 
 - type: replace
   path: /instance_groups/name=metricsforwarder/instances
   value: 2
 - type: replace
   path: /instance_groups/name=metricsforwarder/vm_type
-  value: m5.large
+  value: t3.medium
 
 #Misc - not worth its own ops file
 - type: remove

--- a/bosh/opsfiles/scaling-stage.yml
+++ b/bosh/opsfiles/scaling-stage.yml
@@ -3,41 +3,41 @@
   value: 2
 - type: replace
   path: /instance_groups/name=scalingengine/vm_type
-  value: t3.medium
+  value: t3.small
 - type: replace
   path: /instance_groups/name=apiserver/instances
   value: 2
 - type: replace
   path: /instance_groups/name=apiserver/vm_type
-  value: t3.medium
+  value: t3.small
 
 - type: replace
   path: /instance_groups/name=scheduler/instances
   value: 2
 - type: replace
   path: /instance_groups/name=scheduler/vm_type
-  value: t3.medium
+  value: t3.small
 
 - type: replace
   path: /instance_groups/name=operator/instances
   value: 2
 - type: replace
   path: /instance_groups/name=operator/vm_type
-  value: t3.medium
+  value: t3.small
 
 - type: replace
   path: /instance_groups/name=eventgenerator/instances
   value: 2
 - type: replace
   path: /instance_groups/name=eventgenerator/vm_type
-  value: t3.medium
+  value: t3.small
 
 - type: replace
   path: /instance_groups/name=metricsforwarder/instances
   value: 2
 - type: replace
   path: /instance_groups/name=metricsforwarder/vm_type
-  value: t3.medium
+  value: t3.small
 
 #Misc - not worth its own ops file
 - type: remove

--- a/bosh/opsfiles/scaling-stage.yml
+++ b/bosh/opsfiles/scaling-stage.yml
@@ -3,41 +3,41 @@
   value: 2
 - type: replace
   path: /instance_groups/name=scalingengine/vm_type
-  value: t3.large
+  value: t3.medium
 - type: replace
   path: /instance_groups/name=apiserver/instances
   value: 2
 - type: replace
   path: /instance_groups/name=apiserver/vm_type
-  value: t3.large
+  value: t3.medium
 
 - type: replace
   path: /instance_groups/name=scheduler/instances
   value: 2
 - type: replace
   path: /instance_groups/name=scheduler/vm_type
-  value: t3.large
+  value: t3.medium
 
 - type: replace
   path: /instance_groups/name=operator/instances
   value: 2
 - type: replace
   path: /instance_groups/name=operator/vm_type
-  value: t3.large
+  value: t3.medium
 
 - type: replace
   path: /instance_groups/name=eventgenerator/instances
   value: 2
 - type: replace
   path: /instance_groups/name=eventgenerator/vm_type
-  value: t3.large
+  value: t3.medium
 
 - type: replace
   path: /instance_groups/name=metricsforwarder/instances
   value: 2
 - type: replace
   path: /instance_groups/name=metricsforwarder/vm_type
-  value: t3.large
+  value: t3.medium
 
 #Misc - not worth its own ops file
 - type: remove

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -640,7 +640,7 @@ resources:
   type: git
   source:
     uri: https://github.com/cloud-gov/cg-deploy-autoscaler.git
-    branch: cw3 #main
+    branch: main
     paths:
     - ci/*
     - bosh/*

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -640,7 +640,7 @@ resources:
   type: git
   source:
     uri: https://github.com/cloud-gov/cg-deploy-autoscaler.git
-    branch: main
+    branch: cw3 #main
     paths:
     - ci/*
     - bosh/*

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -268,6 +268,7 @@ jobs:
     - get: cf-stemcell-jammy
       passed: [deploy-as-development]
       trigger: true
+    - get: pipeline-tasks
   - task: terraform-secrets
     file: autoscaler-manifests/ci/terraform-secrets.yml
   - put: autoscaler-deployment-staging
@@ -293,6 +294,17 @@ jobs:
       vars_files:
       - autoscaler-manifests/bosh/varsfiles/staging.yml
       - terraform-secrets/terraform.yml
+  - task: enable-service-access
+    file: pipeline-tasks/set-plan-visibility.yml
+    params:
+      CF_API_URL: ((cf.staging.api))
+      CF_USERNAME: ((cf.staging.admin_user))
+      CF_PASSWORD: ((cf.staging.admin_password))
+      CF_ORGANIZATION: ((broker-organization))
+      CF_SPACE: ((broker-space))
+      BROKER_NAME: ((broker-name))
+      SERVICES: ((cf.staging.services))
+      SERVICE_ORGANIZATION: ((cf.staging.service_organization))
   on_success:
     put: slack
     params:
@@ -443,6 +455,7 @@ jobs:
     - get: cf-stemcell-jammy
       passed: [deploy-as-staging]
       #trigger: true
+    - get: pipeline-tasks
   - task: terraform-secrets
     file: autoscaler-manifests/ci/terraform-secrets.yml
   - put: autoscaler-deployment-production
@@ -468,7 +481,17 @@ jobs:
       vars_files:
       - autoscaler-manifests/bosh/varsfiles/production.yml
       - terraform-secrets/terraform.yml
-
+  - task: enable-service-access
+    file: pipeline-tasks/set-plan-visibility.yml
+    params:
+      CF_API_URL: ((cf.production.api))
+      CF_USERNAME: ((cf.production.admin_user))
+      CF_PASSWORD: ((cf.production.admin_password))
+      CF_ORGANIZATION: ((broker-organization))
+      CF_SPACE: ((broker-space))
+      BROKER_NAME: ((broker-name))
+      SERVICES: ((cf.production.services))
+      SERVICE_ORGANIZATION: ((cf.production.service_organization))
   on_success:
     put: slack
     params:
@@ -634,7 +657,6 @@ resources:
 
 - name: pipeline-tasks
   type: git
-  icon: github-circle
   source:
     uri: ((pipeline-tasks-git-url))
     branch: main

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -445,16 +445,16 @@ jobs:
   - in_parallel:
     - get: app-autoscaler-release
       passed: [deploy-as-staging]
-      #trigger: true
+      trigger: true
     - get: autoscaler-manifests
       resource: autoscaler-manifests
       passed: [acceptance-tests-api-staging, acceptance-tests-broker-staging]
-      #trigger: true
+      trigger: true
     - get: terraform-yaml
       resource: terraform-yaml-production
     - get: cf-stemcell-jammy
       passed: [deploy-as-staging]
-      #trigger: true
+      trigger: true
     - get: pipeline-tasks
   - task: terraform-secrets
     file: autoscaler-manifests/ci/terraform-secrets.yml


### PR DESCRIPTION
## Changes proposed in this pull request:

- Adding/updating sections of the main README
- Scaling dev/stage/prod to use smaller instance sizes for now
- Update stage/prod to add a task to enable service access for a list of organizations
- Part of https://github.com/cloud-gov/product/issues/2972

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None
