### PR TITLE
Get `app` tests working for app-autoscaler

### DIFF
--- a/README.md
+++ b/README.md
@@ -504,3 +504,4 @@ In no particular order:
  - Will also need to circle back to the RDS instances, will likely want to add REINDEX jobs to some of the tables which store metrics, scaling history and other tables which have a high frequency of deletes.
  - The defaults for data retentions for metrics history, scaling history and others are kept at the defaults defined in the spec, an example of this can be seen [here](https://github.com/cloudfoundry/app-autoscaler-release/blob/main/jobs/operator/spec#L215-L217).
  - Policies with recurring or date schedules still require scaling rules with a metric type defined.  If you want to force an app to scale at a particular make sure that the scaling rules are easy to achieve (ie: cpu > 0)
+ - The dynamic_policy_test.go tests for disk will fail with the default 128MB of memory in Staging and Production (oddly works fine in development), this was bumped in the configuration file to 1024 MB for the `app` tests

--- a/bosh/opsfiles/bosh-dns-cf-deployment-name.yml
+++ b/bosh/opsfiles/bosh-dns-cf-deployment-name.yml
@@ -89,7 +89,7 @@
 
 - type: remove
   path: /addons/name=bosh-dns-aliases/jobs/name=bosh-dns-aliases/properties/aliases/domain=((deployment_name)).autoscalerpostgres.service.cf.internal
-  
+
 - type: remove
   path: /domains/metricsgateway
 
@@ -98,3 +98,12 @@
 
 - type: remove
   path: /domains/postgres
+
+
+- type: replace
+  path: /domains/metricsforwarder?
+  value: app-autoscaler.metricsforwarder.service.cf.internal
+
+- type: replace
+  path: /domains/operator?
+  value: app-autoscaler.operator.service.cf.internal

--- a/bosh/opsfiles/bosh-dns-cf-deployment-name.yml
+++ b/bosh/opsfiles/bosh-dns-cf-deployment-name.yml
@@ -74,7 +74,7 @@
       instance_group: metricsforwarder
       network: default
       query: '*'
-      
+
 - type: replace
   path: /addons/name=bosh-dns-aliases/jobs/name=bosh-dns-aliases/properties/aliases/-
   value:
@@ -85,3 +85,15 @@
       instance_group: operator
       network: default
       query: '*'
+
+- type: remove
+  path: /addons/name=bosh-dns-aliases/jobs/name=bosh-dns-aliases/properties/aliases/domain=app-autoscaler.autoscalerpostgres.service.cf.internal
+
+- type: remove
+  path: /domains/metricsgateway
+
+- type: remove
+  path: /domains/metricsserver
+
+- type: remove
+  path: /domains/postgres

--- a/bosh/opsfiles/bosh-dns-cf-deployment-name.yml
+++ b/bosh/opsfiles/bosh-dns-cf-deployment-name.yml
@@ -86,9 +86,10 @@
       network: default
       query: '*'
 
-- type: remove
-  path: /addons/name=bosh-dns-aliases/jobs/name=bosh-dns-aliases/properties/aliases/domain=app-autoscaler.autoscalerpostgres.service.cf.internal
 
+- type: remove
+  path: /addons/name=bosh-dns-aliases/jobs/name=bosh-dns-aliases/properties/aliases/domain=((deployment_name)).autoscalerpostgres.service.cf.internal
+  
 - type: remove
   path: /domains/metricsgateway
 

--- a/bosh/opsfiles/bosh-dns-cf-deployment-name.yml
+++ b/bosh/opsfiles/bosh-dns-cf-deployment-name.yml
@@ -63,3 +63,25 @@
       instance_group: log-cache
       network: default
       query: '*'
+
+- type: replace
+  path: /addons/name=bosh-dns-aliases/jobs/name=bosh-dns-aliases/properties/aliases/-
+  value:
+    domain: app-autoscaler.metricsforwarder.service.cf.internal
+    targets:
+    - deployment: app-autoscaler
+      domain: bosh
+      instance_group: metricsforwarder
+      network: default
+      query: '*'
+      
+- type: replace
+  path: /addons/name=bosh-dns-aliases/jobs/name=bosh-dns-aliases/properties/aliases/-
+  value:
+    domain: app-autoscaler.operator.service.cf.internal
+    targets:
+    - deployment: app-autoscaler
+      domain: bosh
+      instance_group: operator
+      network: default
+      query: '*'

--- a/bosh/opsfiles/certificates.yml
+++ b/bosh/opsfiles/certificates.yml
@@ -1,4 +1,5 @@
-# Used
+# Reset default duration
+## Used
 - type: remove
   path: /variables/name=eventgenerator_client_cert/options/duration?
 - type: remove
@@ -13,19 +14,10 @@
   path: /variables/name=scheduler_client_cert/options/duration?
 - type: remove
   path: /variables/name=scheduler_server_cert/options/duration?
-- type: replace
-  path: /variables/name=app_autoscaler_ca_cert/options/duration?
-  value: 3650
-- type: replace
-  path: /variables/name=metric_scraper_ca/options/duration?
-  value: 3650
-# Not used, but covering bases
-- type: remove
-  path: /variables/name=apiserver_server_cert/options/duration?
-- type: remove
-  path: /variables/name=loggr_syslog_agent_cache_tls/options/duration?
 - type: remove
   path: /variables/name=loggr_syslog_agent_metrics/options/duration?
+- type: remove
+  path: /variables/name=loggr_syslog_agent_cache_tls/options/duration?
 - type: remove
   path: /variables/name=loggr_syslog_agent_tls/options/duration?
 - type: remove
@@ -36,39 +28,137 @@
   path: /variables/name=loggr_syslog_binding_cache_tls/options/duration?
 - type: remove
   path: /variables/name=metricsforwarder_autoscaler_metricsforwarder_loggregator_tls/options/duration?
+- type: replace
+  path: /variables/name=app_autoscaler_ca_cert/options/duration?
+  value: 3650
+- type: replace
+  path: /variables/name=metric_scraper_ca/options/duration?
+  value: 3650
+## Not used, but covering bases
+- type: remove
+  path: /variables/name=apiserver_server_cert/options/duration?
 - type: remove
   path: /variables/name=servicebroker_server_cert/options/duration?
 
 
-# Add certs for operator and metricsforwarder for route_registrar
+# Reset default key_length
+
+- type: remove
+  path: /variables/name=eventgenerator_client_cert/options/key_length?
+## Used
+- type: remove
+  path: /variables/name=eventgenerator_client_cert/options/key_length?
+- type: remove
+  path: /variables/name=eventgenerator_server_cert/options/key_length?
+- type: remove
+  path: /variables/name=loggregator_agent_metrics_tls/options/key_length?
+- type: remove
+  path: /variables/name=scalingengine_client_cert/options/key_length?
+- type: remove
+  path: /variables/name=scalingengine_server_cert/options/key_length?
+- type: remove
+  path: /variables/name=scheduler_client_cert/options/key_length?
+- type: remove
+  path: /variables/name=scheduler_server_cert/options/key_length?
+- type: remove
+  path: /variables/name=loggr_syslog_agent_metrics/options/key_length?
+- type: remove
+  path: /variables/name=loggr_syslog_agent_cache_tls/options/key_length?
+- type: remove
+  path: /variables/name=loggr_syslog_agent_tls/options/key_length?
+- type: remove
+  path: /variables/name=loggr_syslog_binding_cache_api_tls/options/key_length?
+- type: remove
+  path: /variables/name=loggr_syslog_binding_cache_metrics/options/key_length?
+- type: remove
+  path: /variables/name=loggr_syslog_binding_cache_tls/options/key_length?
+- type: remove
+  path: /variables/name=metricsforwarder_autoscaler_metricsforwarder_loggregator_tls/options/key_length?
+- type: remove
+  path: /variables/name=app_autoscaler_ca_cert/options/key_length?
+- type: remove
+  path: /variables/name=metric_scraper_ca/options/key_length?
+## Not used, but covering bases
+- type: remove
+  path: /variables/name=apiserver_server_cert/options/key_length?
+- type: remove
+  path: /variables/name=servicebroker_server_cert/options/key_length?
+
+
+
+
+
+
+
+# Add certs for route_registrar to use
 - type: replace
   path: /variables/-
   value:
-    name: operator_server_cert
+    name: operator_server_rr_cert
     options:
       alternative_names:
       - app-autoscaler.operator.service.cf.internal
       ca: app_autoscaler_ca_cert
       common_name: app-autoscaler.operator.service.cf.internal
-      extended_key_usage:
-      - client_auth
-      - server_auth
-      key_length: 4096
     type: certificate
     update_mode: converge
 
 - type: replace
   path: /variables/-
   value:
-    name: metricsforwarder_server_cert
+    name: metricsforwarder_server_rr_cert
     options:
       alternative_names:
       - app-autoscaler.metricsforwarder.service.cf.internal
       ca: app_autoscaler_ca_cert
       common_name: app-autoscaler.metricsforwarder.service.cf.internal
-      extended_key_usage:
-      - client_auth
-      - server_auth
-      key_length: 4096
+    type: certificate
+    update_mode: converge
+
+- type: replace
+  path: /variables/-
+  value:
+    name: scalingengine_server_rr_cert
+    options:
+      alternative_names:
+      - app-autoscaler.scalingengine.service.cf.internal
+      ca: app_autoscaler_ca_cert
+      common_name: app-autoscaler.scalingengine.service.cf.internal
+    type: certificate
+    update_mode: converge
+
+- type: replace
+  path: /variables/-
+  value:
+    name: apiserver_server_rr_cert
+    options:
+      alternative_names:
+      - app-autoscaler.apiserver.service.cf.internal
+      ca: app_autoscaler_ca_cert
+      common_name: app-autoscaler.apiserver.service.cf.internal
+    type: certificate
+    update_mode: converge
+
+- type: replace
+  path: /variables/-
+  value:
+    name: scheduler_server_rr_cert
+    options:
+      alternative_names:
+      - app-autoscaler.autoscalerscheduler.service.cf.internal
+      ca: app_autoscaler_ca_cert
+      common_name: app-autoscaler.autoscalerscheduler.service.cf.internal
+    type: certificate
+    update_mode: converge
+
+- type: replace
+  path: /variables/-
+  value:
+    name: eventgenerator_server_rr_cert
+    options:
+      alternative_names:
+      - app-autoscaler.eventgenerator.service.cf.internal
+      ca: app_autoscaler_ca_cert
+      common_name: app-autoscaler.eventgenerator.service.cf.internal
     type: certificate
     update_mode: converge

--- a/bosh/opsfiles/certificates.yml
+++ b/bosh/opsfiles/certificates.yml
@@ -38,3 +38,37 @@
   path: /variables/name=metricsforwarder_autoscaler_metricsforwarder_loggregator_tls/options/duration?
 - type: remove
   path: /variables/name=servicebroker_server_cert/options/duration?
+
+
+# Add certs for operator and metricsforwarder for route_registrar
+- type: replace
+  path: /variables/-
+  value:
+    name: operator_server_cert
+    options:
+      alternative_names:
+      - app-autoscaler.operator.service.cf.internal
+      ca: app_autoscaler_ca_cert
+      common_name: app-autoscaler.operator.service.cf.internal
+      extended_key_usage:
+      - client_auth
+      - server_auth
+      key_length: 4096
+    type: certificate
+    update_mode: converge
+
+- type: replace
+  path: /variables/-
+  value:
+    name: metricsforwarder_server_cert
+    options:
+      alternative_names:
+      - app-autoscaler.metricsforwarder.service.cf.internal
+      ca: app_autoscaler_ca_cert
+      common_name: app-autoscaler.metricsforwarder.service.cf.internal
+      extended_key_usage:
+      - client_auth
+      - server_auth
+      key_length: 4096
+    type: certificate
+    update_mode: converge

--- a/bosh/opsfiles/releases.yml
+++ b/bosh/opsfiles/releases.yml
@@ -6,6 +6,6 @@
     url: "https://bosh.io/d/github.com/cloudfoundry-incubator/app-autoscaler-release?v=12.2.2"
     sha1: "a1fffce71219318d1fb27ec5fc3ff84e757337ed"
 
-# Note used
+# Not used
 - type: remove
   path: /releases/name=postgres

--- a/bosh/opsfiles/releases.yml
+++ b/bosh/opsfiles/releases.yml
@@ -5,3 +5,7 @@
     version: "12.2.2"
     url: "https://bosh.io/d/github.com/cloudfoundry-incubator/app-autoscaler-release?v=12.2.2"
     sha1: "a1fffce71219318d1fb27ec5fc3ff84e757337ed"
+
+# Note used
+- type: remove
+  path: /releases/name=postgres

--- a/bosh/opsfiles/route-registrar-tls.yml
+++ b/bosh/opsfiles/route-registrar-tls.yml
@@ -49,27 +49,27 @@
 
 
 #apiserver (broker 6102)
-- type: replace
-  path: /instance_groups/name=apiserver/jobs/name=golangapiserver/properties/autoscaler/apiserver/broker/server/ca_cert?
-  value: ((app_autoscaler_ca_cert.ca))  
-- type: replace
-  path: /instance_groups/name=apiserver/jobs/name=golangapiserver/properties/autoscaler/apiserver/broker/server/server_cert?
-  value: ((apiserver_server_rr_cert.certificate))
-- type: replace
-  path: /instance_groups/name=apiserver/jobs/name=golangapiserver/properties/autoscaler/apiserver/broker/server/server_key?
-  value: ((apiserver_server_rr_cert.private_key))
+#- type: replace
+#  path: /instance_groups/name=apiserver/jobs/name=golangapiserver/properties/autoscaler/apiserver/broker/server/ca_cert?
+#  value: ((app_autoscaler_ca_cert.ca))  
+#- type: replace
+#  path: /instance_groups/name=apiserver/jobs/name=golangapiserver/properties/autoscaler/apiserver/broker/server/server_cert?
+#  value: ((apiserver_server_rr_cert.certificate))
+#- type: replace
+#  path: /instance_groups/name=apiserver/jobs/name=golangapiserver/properties/autoscaler/apiserver/broker/server/server_key?
+#  value: ((apiserver_server_rr_cert.private_key))
 
-- type: remove
-  path: /instance_groups/name=apiserver/jobs/name=route_registrar/properties/route_registrar/routes/name=autoscaler_service_broker/port
-- type: replace
-  path: /instance_groups/name=apiserver/jobs/name=route_registrar/properties/route_registrar/routes/name=autoscaler_service_broker/tls_port?
-  value: 6102
+#- type: remove
+#  path: /instance_groups/name=apiserver/jobs/name=route_registrar/properties/route_registrar/routes/name=autoscaler_service_broker/port
+#- type: replace
+#  path: /instance_groups/name=apiserver/jobs/name=route_registrar/properties/route_registrar/routes/name=autoscaler_service_broker/tls_port?
+#  value: 6102
 - type: replace
   path: /instance_groups/name=apiserver/jobs/name=route_registrar/properties/route_registrar/routes/name=autoscaler_service_broker/timeout?
   value: 10s
-- type: replace
-  path: /instance_groups/name=apiserver/jobs/name=route_registrar/properties/route_registrar/routes/name=autoscaler_service_broker/server_cert_domain_san?
-  value: app-autoscaler.apiserver.service.cf.internal
+#- type: replace
+#  path: /instance_groups/name=apiserver/jobs/name=route_registrar/properties/route_registrar/routes/name=autoscaler_service_broker/server_cert_domain_san?
+#  value: app-autoscaler.apiserver.service.cf.internal
 
 
 

--- a/bosh/opsfiles/route-registrar-tls.yml
+++ b/bosh/opsfiles/route-registrar-tls.yml
@@ -1,0 +1,210 @@
+
+#scalingengine (health 6204)
+- type: replace
+  path: /instance_groups/name=scalingengine/jobs/name=scalingengine/properties/autoscaler/scalingengine/health/ca_cert?
+  value: ((app_autoscaler_ca_cert.ca))
+- type: replace
+  path: /instance_groups/name=scalingengine/jobs/name=scalingengine/properties/autoscaler/scalingengine/health/server_cert?
+  value: ((scalingengine_server_rr_cert.certificate))
+- type: replace
+  path: /instance_groups/name=scalingengine/jobs/name=scalingengine/properties/autoscaler/scalingengine/health/server_key?
+  value: ((scalingengine_server_rr_cert.private_key))
+
+- type: remove
+  path: /instance_groups/name=scalingengine/jobs/name=route_registrar/properties/route_registrar/routes/name=autoscaler_scalingengine_health/port
+- type: replace
+  path: /instance_groups/name=scalingengine/jobs/name=route_registrar/properties/route_registrar/routes/name=autoscaler_scalingengine_health/tls_port?
+  value: 6204
+- type: replace
+  path: /instance_groups/name=scalingengine/jobs/name=route_registrar/properties/route_registrar/routes/name=autoscaler_scalingengine_health/timeout?
+  value: 10s
+- type: replace
+  path: /instance_groups/name=scalingengine/jobs/name=route_registrar/properties/route_registrar/routes/name=autoscaler_scalingengine_health/server_cert_domain_san?
+  value: app-autoscaler.scalingengine.service.cf.internal
+
+
+
+#apiserver (api 6101)
+- type: replace
+  path: /instance_groups/name=apiserver/jobs/name=golangapiserver/properties/autoscaler/apiserver/public_api/server/ca_cert?
+  value: ((app_autoscaler_ca_cert.ca))
+- type: replace
+  path: /instance_groups/name=apiserver/jobs/name=golangapiserver/properties/autoscaler/apiserver/public_api/server/server_cert?
+  value: ((apiserver_server_rr_cert.certificate))
+- type: replace
+  path: /instance_groups/name=apiserver/jobs/name=golangapiserver/properties/autoscaler/apiserver/public_api/server/server_key?
+  value: ((apiserver_server_rr_cert.private_key))
+
+- type: remove
+  path: /instance_groups/name=apiserver/jobs/name=route_registrar/properties/route_registrar/routes/name=api_server/port
+- type: replace
+  path: /instance_groups/name=apiserver/jobs/name=route_registrar/properties/route_registrar/routes/name=api_server/tls_port?
+  value: 6101
+- type: replace
+  path: /instance_groups/name=apiserver/jobs/name=route_registrar/properties/route_registrar/routes/name=api_server/timeout?
+  value: 10s
+- type: replace
+  path: /instance_groups/name=apiserver/jobs/name=route_registrar/properties/route_registrar/routes/name=api_server/server_cert_domain_san?
+  value: app-autoscaler.apiserver.service.cf.internal
+
+
+#apiserver (broker 6102)
+- type: replace
+  path: /instance_groups/name=apiserver/jobs/name=golangapiserver/properties/autoscaler/apiserver/broker/server/ca_cert?
+  value: ((app_autoscaler_ca_cert.ca))  
+- type: replace
+  path: /instance_groups/name=apiserver/jobs/name=golangapiserver/properties/autoscaler/apiserver/broker/server/server_cert?
+  value: ((apiserver_server_rr_cert.certificate))
+- type: replace
+  path: /instance_groups/name=apiserver/jobs/name=golangapiserver/properties/autoscaler/apiserver/broker/server/server_key?
+  value: ((apiserver_server_rr_cert.private_key))
+
+- type: remove
+  path: /instance_groups/name=apiserver/jobs/name=route_registrar/properties/route_registrar/routes/name=autoscaler_service_broker/port
+- type: replace
+  path: /instance_groups/name=apiserver/jobs/name=route_registrar/properties/route_registrar/routes/name=autoscaler_service_broker/tls_port?
+  value: 6102
+- type: replace
+  path: /instance_groups/name=apiserver/jobs/name=route_registrar/properties/route_registrar/routes/name=autoscaler_service_broker/timeout?
+  value: 10s
+- type: replace
+  path: /instance_groups/name=apiserver/jobs/name=route_registrar/properties/route_registrar/routes/name=autoscaler_service_broker/server_cert_domain_san?
+  value: app-autoscaler.apiserver.service.cf.internal
+
+
+
+#scheduler (health 6202)
+- type: replace
+  path: /instance_groups/name=scheduler/jobs/name=scheduler/properties/autoscaler/scheduler/health/ca_cert?
+  value: ((app_autoscaler_ca_cert.ca))  
+- type: replace
+  path: /instance_groups/name=scheduler/jobs/name=scheduler/properties/autoscaler/scheduler/health/server_cert?
+  value: ((scheduler_server_rr_cert.certificate))
+- type: replace
+  path: /instance_groups/name=scheduler/jobs/name=scheduler/properties/autoscaler/scheduler/health/server_key?
+  value: ((scheduler_server_rr_cert.private_key))
+
+- type: remove
+  path: /instance_groups/name=scheduler/jobs/name=route_registrar/properties/route_registrar/routes/name=autoscaler_scheduler_health/port
+- type: replace
+  path: /instance_groups/name=scheduler/jobs/name=route_registrar/properties/route_registrar/routes/name=autoscaler_scheduler_health/tls_port?
+  value: 6202
+- type: replace
+  path: /instance_groups/name=scheduler/jobs/name=route_registrar/properties/route_registrar/routes/name=autoscaler_scheduler_health/timeout?
+  value: 10s
+- type: replace
+  path: /instance_groups/name=scheduler/jobs/name=route_registrar/properties/route_registrar/routes/name=autoscaler_scheduler_health/server_cert_domain_san?
+  value: app-autoscaler.autoscalerscheduler.service.cf.internal
+
+
+#operator (health 6208)
+- type: replace
+  path: /instance_groups/name=operator/jobs/name=operator/properties/autoscaler/operator/health/ca_cert?
+  value: ((app_autoscaler_ca_cert.ca))  
+- type: replace
+  path: /instance_groups/name=operator/jobs/name=operator/properties/autoscaler/operator/health/server_cert?
+  value: ((operator_server_rr_cert.certificate))
+- type: replace
+  path: /instance_groups/name=operator/jobs/name=operator/properties/autoscaler/operator/health/server_key?
+  value: ((operator_server_rr_cert.private_key))
+
+- type: remove
+  path: /instance_groups/name=operator/jobs/name=route_registrar/properties/route_registrar/routes/name=autoscaler_operator_health/port
+- type: replace
+  path: /instance_groups/name=operator/jobs/name=route_registrar/properties/route_registrar/routes/name=autoscaler_operator_health/tls_port?
+  value: 6208
+- type: replace
+  path: /instance_groups/name=operator/jobs/name=route_registrar/properties/route_registrar/routes/name=autoscaler_operator_health/timeout?
+  value: 10s
+- type: replace
+  path: /instance_groups/name=operator/jobs/name=route_registrar/properties/route_registrar/routes/name=autoscaler_operator_health/server_cert_domain_san?
+  value: app-autoscaler.operator.service.cf.internal
+
+
+#eventgenerator (health 6205)
+- type: replace
+  path: /instance_groups/name=eventgenerator/jobs/name=eventgenerator/properties/autoscaler/eventgenerator/health/ca_cert?
+  value: ((app_autoscaler_ca_cert.ca))  
+- type: replace
+  path: /instance_groups/name=eventgenerator/jobs/name=eventgenerator/properties/autoscaler/eventgenerator/health/server_cert?
+  value: ((eventgenerator_server_rr_cert.certificate))
+- type: replace
+  path: /instance_groups/name=eventgenerator/jobs/name=eventgenerator/properties/autoscaler/eventgenerator/health/server_key?
+  value: ((eventgenerator_server_rr_cert.private_key))
+
+- type: remove
+  path: /instance_groups/name=eventgenerator/jobs/name=route_registrar/properties/route_registrar/routes/name=autoscaler_eventgenerator_health/port
+- type: replace
+  path: /instance_groups/name=eventgenerator/jobs/name=route_registrar/properties/route_registrar/routes/name=autoscaler_eventgenerator_health/tls_port?
+  value: 6205
+- type: replace
+  path: /instance_groups/name=eventgenerator/jobs/name=route_registrar/properties/route_registrar/routes/name=autoscaler_eventgenerator_health/timeout?
+  value: 10s
+- type: replace
+  path: /instance_groups/name=eventgenerator/jobs/name=route_registrar/properties/route_registrar/routes/name=autoscaler_eventgenerator_health/server_cert_domain_san?
+  value: app-autoscaler.eventgenerator.service.cf.internal
+
+
+
+
+# metricsforwarder (metrics & mtls 6201)
+- type: replace
+  path: /instance_groups/name=metricsforwarder/jobs/name=metricsforwarder/properties/autoscaler/metricsforwarder/server/ca_cert?
+  value: ((app_autoscaler_ca_cert.ca))  
+- type: replace
+  path: /instance_groups/name=metricsforwarder/jobs/name=metricsforwarder/properties/autoscaler/metricsforwarder/server/server_cert?
+  value: ((metricsforwarder_server_rr_cert.certificate))
+- type: replace
+  path: /instance_groups/name=metricsforwarder/jobs/name=metricsforwarder/properties/autoscaler/metricsforwarder/server/server_key?
+  value: ((metricsforwarder_server_rr_cert.private_key))
+
+
+- type: remove
+  path: /instance_groups/name=metricsforwarder/jobs/name=route_registrar/properties/route_registrar/routes/name=autoscaler_metrics_forwarder/port
+- type: replace
+  path: /instance_groups/name=metricsforwarder/jobs/name=route_registrar/properties/route_registrar/routes/name=autoscaler_metrics_forwarder/tls_port?
+  value: 6201
+- type: replace
+  path: /instance_groups/name=metricsforwarder/jobs/name=route_registrar/properties/route_registrar/routes/name=autoscaler_metrics_forwarder/timeout?
+  value: 10s
+- type: replace
+  path: /instance_groups/name=metricsforwarder/jobs/name=route_registrar/properties/route_registrar/routes/name=autoscaler_metrics_forwarder/server_cert_domain_san?
+  value: app-autoscaler.metricsforwarder.service.cf.internal
+
+- type: remove
+  path: /instance_groups/name=metricsforwarder/jobs/name=route_registrar/properties/route_registrar/routes/name=autoscaler_metrics_forwarder_mtls/port
+- type: replace
+  path: /instance_groups/name=metricsforwarder/jobs/name=route_registrar/properties/route_registrar/routes/name=autoscaler_metrics_forwarder_mtls/tls_port?
+  value: 6201
+- type: replace
+  path: /instance_groups/name=metricsforwarder/jobs/name=route_registrar/properties/route_registrar/routes/name=autoscaler_metrics_forwarder_mtls/timeout?
+  value: 10s
+- type: replace
+  path: /instance_groups/name=metricsforwarder/jobs/name=route_registrar/properties/route_registrar/routes/name=autoscaler_metrics_forwarder_mtls/server_cert_domain_san?
+  value: app-autoscaler.metricsforwarder.service.cf.internal
+
+
+
+#metricsforwarder (health 6403)
+- type: replace
+  path: /instance_groups/name=metricsforwarder/jobs/name=metricsforwarder/properties/autoscaler/metricsforwarder/health/ca_cert?
+  value: ((app_autoscaler_ca_cert.ca))  
+- type: replace
+  path: /instance_groups/name=metricsforwarder/jobs/name=metricsforwarder/properties/autoscaler/metricsforwarder/health/server_cert?
+  value: ((metricsforwarder_server_rr_cert.certificate))
+- type: replace
+  path: /instance_groups/name=metricsforwarder/jobs/name=metricsforwarder/properties/autoscaler/metricsforwarder/health/server_key?
+  value: ((metricsforwarder_server_rr_cert.private_key))
+
+- type: remove
+  path: /instance_groups/name=metricsforwarder/jobs/name=route_registrar/properties/route_registrar/routes/name=autoscaler_metricsforwarder_health/port
+- type: replace
+  path: /instance_groups/name=metricsforwarder/jobs/name=route_registrar/properties/route_registrar/routes/name=autoscaler_metricsforwarder_health/tls_port?
+  value: 6403
+- type: replace
+  path: /instance_groups/name=metricsforwarder/jobs/name=route_registrar/properties/route_registrar/routes/name=autoscaler_metricsforwarder_health/timeout?
+  value: 10s
+- type: replace
+  path: /instance_groups/name=metricsforwarder/jobs/name=route_registrar/properties/route_registrar/routes/name=autoscaler_metricsforwarder_health/server_cert_domain_san?
+  value: app-autoscaler.metricsforwarder.service.cf.internal
+

--- a/bosh/opsfiles/route-registrar-tls.yml
+++ b/bosh/opsfiles/route-registrar-tls.yml
@@ -25,27 +25,27 @@
 
 
 #apiserver (api 6101)
-- type: replace
-  path: /instance_groups/name=apiserver/jobs/name=golangapiserver/properties/autoscaler/apiserver/public_api/server/ca_cert?
-  value: ((app_autoscaler_ca_cert.ca))
-- type: replace
-  path: /instance_groups/name=apiserver/jobs/name=golangapiserver/properties/autoscaler/apiserver/public_api/server/server_cert?
-  value: ((apiserver_server_rr_cert.certificate))
-- type: replace
-  path: /instance_groups/name=apiserver/jobs/name=golangapiserver/properties/autoscaler/apiserver/public_api/server/server_key?
-  value: ((apiserver_server_rr_cert.private_key))
+#- type: replace
+#  path: /instance_groups/name=apiserver/jobs/name=golangapiserver/properties/autoscaler/apiserver/public_api/server/ca_cert?
+#  value: ((app_autoscaler_ca_cert.ca))
+#- type: replace
+#  path: /instance_groups/name=apiserver/jobs/name=golangapiserver/properties/autoscaler/apiserver/public_api/server/server_cert?
+#  value: ((apiserver_server_rr_cert.certificate))
+#- type: replace
+#  path: /instance_groups/name=apiserver/jobs/name=golangapiserver/properties/autoscaler/apiserver/public_api/server/server_key?
+#  value: ((apiserver_server_rr_cert.private_key))
 
-- type: remove
-  path: /instance_groups/name=apiserver/jobs/name=route_registrar/properties/route_registrar/routes/name=api_server/port
-- type: replace
-  path: /instance_groups/name=apiserver/jobs/name=route_registrar/properties/route_registrar/routes/name=api_server/tls_port?
-  value: 6101
+#- type: remove
+#  path: /instance_groups/name=apiserver/jobs/name=route_registrar/properties/route_registrar/routes/name=api_server/port
+#- type: replace
+#  path: /instance_groups/name=apiserver/jobs/name=route_registrar/properties/route_registrar/routes/name=api_server/tls_port?
+#  value: 6101
 - type: replace
   path: /instance_groups/name=apiserver/jobs/name=route_registrar/properties/route_registrar/routes/name=api_server/timeout?
   value: 10s
-- type: replace
-  path: /instance_groups/name=apiserver/jobs/name=route_registrar/properties/route_registrar/routes/name=api_server/server_cert_domain_san?
-  value: app-autoscaler.apiserver.service.cf.internal
+#- type: replace
+#  path: /instance_groups/name=apiserver/jobs/name=route_registrar/properties/route_registrar/routes/name=api_server/server_cert_domain_san?
+#  value: app-autoscaler.apiserver.service.cf.internal
 
 
 #apiserver (broker 6102)

--- a/bosh/opsfiles/scaling-dev.yml
+++ b/bosh/opsfiles/scaling-dev.yml
@@ -38,7 +38,3 @@
 - type: replace
   path: /instance_groups/name=metricsforwarder/vm_type
   value: t3.small
-
-#Misc - not worth its own ops file
-- type: remove
-  path: /releases/name=postgres

--- a/bosh/opsfiles/scaling-prod.yml
+++ b/bosh/opsfiles/scaling-prod.yml
@@ -38,7 +38,3 @@
 - type: replace
   path: /instance_groups/name=metricsforwarder/vm_type
   value: t3.medium
-
-#Misc - not worth its own ops file
-- type: remove
-  path: /releases/name=postgres

--- a/bosh/opsfiles/scaling-stage.yml
+++ b/bosh/opsfiles/scaling-stage.yml
@@ -39,6 +39,3 @@
   path: /instance_groups/name=metricsforwarder/vm_type
   value: t3.small
 
-#Misc - not worth its own ops file
-- type: remove
-  path: /releases/name=postgres

--- a/ci/acceptance-tests.sh
+++ b/ci/acceptance-tests.sh
@@ -13,7 +13,7 @@ tar -xzf app-autoscaler-acceptance-tests.tgz
 
 cd acceptance
 
-if [ "$COMPONENT_TO_TEST" = "app"]; then 
+if [ "$COMPONENT_TO_TEST" = "app" ]; then 
 
 
   echo "######################################################################"

--- a/ci/acceptance-tests.sh
+++ b/ci/acceptance-tests.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 
 set -eu
-echo "###################################"
+echo "######################################################################"
 echo "This is the installed go version: $(go version)"
 echo "This is the installed cf cli version: $(cf -v)"
 echo "This is the ACCEPTANCE_TESTS_VERSION version: ${ACCEPTANCE_TESTS_VERSION}"
-echo "###################################"
+echo "######################################################################"
 
 # Get the tarball with the test
 wget -O app-autoscaler-acceptance-tests.tgz  https://github.com/cloudfoundry/app-autoscaler-release/releases/download/v${ACCEPTANCE_TESTS_VERSION}/app-autoscaler-acceptance-tests-v${ACCEPTANCE_TESTS_VERSION}.tgz
@@ -13,22 +13,36 @@ tar -xzf app-autoscaler-acceptance-tests.tgz
 
 cd acceptance
 
-
-echo "###################################"
-echo "Logging in and create a test org/space, IMPORTANT: bind the public_networks_egress ASG"
-echo "###################################"
-#cf login -a ${CF_API} -u ${CF_ADMIN_USER} -p "${CF_ADMIN_PASSWORD}" -o cloud-gov -s services
-#cf create-org ${AUTOSCALER_CF_ORG}
-#cf create-space ${AUTOSCALER_CF_SPACE} -o ${AUTOSCALER_CF_ORG}
-#cf bind-security-group public_networks_egress ${AUTOSCALER_CF_ORG} --space ${AUTOSCALER_CF_SPACE}
+if [ "$COMPONENT_TO_TEST" = "app"] then 
 
 
-# Set the config file needed for the acceptance tests
-echo "###################################"
-echo "Writing config file for acceptance tests to acceptance/integration_config.json, do not ever print this out into concourse logs!"
-echo "###################################"
+  echo "######################################################################"
+  echo "Removing test for cpuutil for v12.2.2"
+  echo "######################################################################"
 
-cat > integration_config.json <<EOF
+  head -n 257 app/dynamic_policy_test.go > dynamic_policy_test.go
+  tail -n +290 app/dynamic_policy_test.go >> dynamic_policy_test.go
+  chmod 644 dynamic_policy_test.go
+  
+  mv app/dynamic_policy_test.go app/dynamic_policy_test.orig.off
+  mv dynamic_policy_test.go app/dynamic_policy_test.go
+
+
+  echo "######################################################################"
+  echo "Logging in and create a test org/space, IMPORTANT: bind the public_networks_egress ASG"
+  echo "######################################################################"
+  cf login -a ${CF_API} -u ${CF_ADMIN_USER} -p "${CF_ADMIN_PASSWORD}" -o cloud-gov -s services
+  cf create-org ${AUTOSCALER_CF_ORG}
+  cf create-space ${AUTOSCALER_CF_SPACE} -o ${AUTOSCALER_CF_ORG}
+  cf bind-security-group public_networks_egress ${AUTOSCALER_CF_ORG} --space ${AUTOSCALER_CF_SPACE}
+  
+  
+  # Set the config file needed for the acceptance tests, the "app" tests need to use a predefined org/space with the ASGs setup
+  echo "######################################################################"
+  echo "Writing config file for acceptance tests to acceptance/integration_config.json, do not ever print this out into concourse logs!"
+  echo "######################################################################"
+  
+  cat > integration_config.json <<EOF
 {
   "api": "${CF_API}",
   "admin_user": "${CF_ADMIN_USER}",
@@ -49,12 +63,36 @@ cat > integration_config.json <<EOF
   "existing_organization": "${AUTOSCALER_CF_ORG}",
   "use_existing_space": true,
   "existing_space": "${AUTOSCALER_CF_SPACE}",
-
-  "cpuutil_scaling_policy_test": {
-    "app_cpu_entitlement": ${APP_CPU_ENTITLEMENT}
-  }
 }
 EOF
+else
+  # Set the config file needed for the acceptance tests, the broker tests fails if it uses an existing org, ASG isn't important
+  echo "######################################################################"
+  echo "Writing config file for acceptance tests to acceptance/integration_config.json, do not ever print this out into concourse logs!"
+  echo "######################################################################"
+  
+  cat > integration_config.json <<EOF
+{
+  "api": "${CF_API}",
+  "admin_user": "${CF_ADMIN_USER}",
+  "admin_password": "${CF_ADMIN_PASSWORD}",
+  "apps_domain": "${CF_APPS_DOMAIN}",
+  "skip_ssl_validation": true,
+  "use_http": false,
+
+  "service_name": "app-autoscaler",
+  "service_plan": "autoscaler-free-plan",
+  "aggregate_interval": 120,
+  "health_endpoints_basic_auth_enabled": true,
+
+  "autoscaler_api": "${AUTOSCALER_API}",
+  "service_offering_enabled": true
+}
+EOF
+fi
+
+
+
 export CONFIG=$PWD/integration_config.json
 
 # Set GINKGO_BINARY since its provided in the tarball, omit this to have it built at runtime
@@ -62,20 +100,20 @@ export GINKGO_BINARY=$PWD/ginkgo_v2_linux_amd64
 
 
 # Run the actual test, pick one: {broker, api, app}
-echo "###################################"
+echo "######################################################################"
 echo "Running ${COMPONENT_TO_TEST} test..."
-echo "###################################"
+echo "######################################################################"
 ./bin/test ${COMPONENT_TO_TEST} #--nodes=4 #--flake-attempts=3
 
 
 
 # Perform the cleanup (drops any created org that is named ASATS*)
-echo "###################################"
+echo "######################################################################"
 echo "Logging in and running cleanup.sh..."
-echo "###################################"
+echo "######################################################################"
 cf login -a ${CF_API} -u ${CF_ADMIN_USER} -p "${CF_ADMIN_PASSWORD}" -o cloud-gov -s services
 ./cleanup.sh
 
-echo "###################################"
+echo "######################################################################"
 echo "~FIN~"
-echo "###################################"
+echo "######################################################################"

--- a/ci/acceptance-tests.sh
+++ b/ci/acceptance-tests.sh
@@ -62,7 +62,7 @@ if [ "$COMPONENT_TO_TEST" = "app" ]; then
   "use_existing_organization": true,
   "existing_organization": "${AUTOSCALER_CF_ORG}",
   "use_existing_space": true,
-  "existing_space": "${AUTOSCALER_CF_SPACE}",
+  "existing_space": "${AUTOSCALER_CF_SPACE}"
 }
 EOF
 else

--- a/ci/acceptance-tests.sh
+++ b/ci/acceptance-tests.sh
@@ -34,6 +34,10 @@ cat > integration_config.json <<EOF
 
   "autoscaler_api": "${AUTOSCALER_API}",
   "service_offering_enabled": true
+
+  "cpuutil_scaling_policy_test": {
+    "app_cpu_entitlement": ${APP_CPU_ENTITLEMENT}
+  }
 }
 EOF
 export CONFIG=$PWD/integration_config.json

--- a/ci/acceptance-tests.sh
+++ b/ci/acceptance-tests.sh
@@ -50,7 +50,7 @@ export GINKGO_BINARY=$PWD/ginkgo_v2_linux_amd64
 echo "###################################"
 echo "Running ${COMPONENT_TO_TEST} test..."
 echo "###################################"
-./bin/test ${COMPONENT_TO_TEST}
+./bin/test ${COMPONENT_TO_TEST} --nodes=4 #--flake-attempts=3
 
 
 

--- a/ci/acceptance-tests.sh
+++ b/ci/acceptance-tests.sh
@@ -49,8 +49,6 @@ cat > integration_config.json <<EOF
   "existing_organization": "${AUTOSCALER_CF_ORG}",
   "use_existing_space": true,
   "existing_space": "${AUTOSCALER_CF_SPACE}",
-  "use_existing_user": true,
-  "existing_user": "${CF_ADMIN_USER}",
 
   "cpuutil_scaling_policy_test": {
     "app_cpu_entitlement": ${APP_CPU_ENTITLEMENT}

--- a/ci/acceptance-tests.sh
+++ b/ci/acceptance-tests.sh
@@ -65,7 +65,7 @@ export GINKGO_BINARY=$PWD/ginkgo_v2_linux_amd64
 echo "###################################"
 echo "Running ${COMPONENT_TO_TEST} test..."
 echo "###################################"
-./bin/test ${COMPONENT_TO_TEST} --nodes=4 #--flake-attempts=3
+./bin/test ${COMPONENT_TO_TEST} #--nodes=4 #--flake-attempts=3
 
 
 

--- a/ci/acceptance-tests.sh
+++ b/ci/acceptance-tests.sh
@@ -13,6 +13,16 @@ tar -xzf app-autoscaler-acceptance-tests.tgz
 
 cd acceptance
 
+
+echo "###################################"
+echo "Logging in and create a test org/space, IMPORTANT: bind the public_networks_egress ASG"
+echo "###################################"
+cf login -a ${CF_API} -u ${CF_ADMIN_USER} -p "${CF_ADMIN_PASSWORD}" -o cloud-gov -s services
+cf create-org ${AUTOSCALER_CF_ORG}
+cf create-space ${AUTOSCALER_CF_SPACE} -o ${AUTOSCALER_CF_ORG}
+cf bind-security-group public_networks_egress ${AUTOSCALER_CF_ORG} --space ${AUTOSCALER_CF_SPACE}
+
+
 # Set the config file needed for the acceptance tests
 echo "###################################"
 echo "Writing config file for acceptance tests to acceptance/integration_config.json, do not ever print this out into concourse logs!"
@@ -34,6 +44,11 @@ cat > integration_config.json <<EOF
 
   "autoscaler_api": "${AUTOSCALER_API}",
   "service_offering_enabled": true,
+
+  "use_existing_organization": true,
+  "existing_organization": "${AUTOSCALER_CF_ORG}",
+  "use_existing_space": true,
+  "existing_space": "${AUTOSCALER_CF_SPACE}",
 
   "cpuutil_scaling_policy_test": {
     "app_cpu_entitlement": ${APP_CPU_ENTITLEMENT}

--- a/ci/acceptance-tests.sh
+++ b/ci/acceptance-tests.sh
@@ -49,7 +49,9 @@ if [[ "$COMPONENT_TO_TEST" = "app" ]]; then
   "use_existing_organization": true,
   "existing_organization": "${AUTOSCALER_CF_ORG}",
   "use_existing_space": true,
-  "existing_space": "${AUTOSCALER_CF_SPACE}"
+  "existing_space": "${AUTOSCALER_CF_SPACE}",
+  
+  "node_memory_limit": 1024
 }
 EOF
 else

--- a/ci/acceptance-tests.sh
+++ b/ci/acceptance-tests.sh
@@ -17,10 +17,10 @@ cd acceptance
 echo "###################################"
 echo "Logging in and create a test org/space, IMPORTANT: bind the public_networks_egress ASG"
 echo "###################################"
-cf login -a ${CF_API} -u ${CF_ADMIN_USER} -p "${CF_ADMIN_PASSWORD}" -o cloud-gov -s services
-cf create-org ${AUTOSCALER_CF_ORG}
-cf create-space ${AUTOSCALER_CF_SPACE} -o ${AUTOSCALER_CF_ORG}
-cf bind-security-group public_networks_egress ${AUTOSCALER_CF_ORG} --space ${AUTOSCALER_CF_SPACE}
+#cf login -a ${CF_API} -u ${CF_ADMIN_USER} -p "${CF_ADMIN_PASSWORD}" -o cloud-gov -s services
+#cf create-org ${AUTOSCALER_CF_ORG}
+#cf create-space ${AUTOSCALER_CF_SPACE} -o ${AUTOSCALER_CF_ORG}
+#cf bind-security-group public_networks_egress ${AUTOSCALER_CF_ORG} --space ${AUTOSCALER_CF_SPACE}
 
 
 # Set the config file needed for the acceptance tests
@@ -49,6 +49,8 @@ cat > integration_config.json <<EOF
   "existing_organization": "${AUTOSCALER_CF_ORG}",
   "use_existing_space": true,
   "existing_space": "${AUTOSCALER_CF_SPACE}",
+  "use_existing_user": true,
+  "existing_user": "${CF_ADMIN_USER}",
 
   "cpuutil_scaling_policy_test": {
     "app_cpu_entitlement": ${APP_CPU_ENTITLEMENT}

--- a/ci/acceptance-tests.sh
+++ b/ci/acceptance-tests.sh
@@ -13,20 +13,7 @@ tar -xzf app-autoscaler-acceptance-tests.tgz
 
 cd acceptance
 
-if [ "$COMPONENT_TO_TEST" = "app" ]; then 
-
-
-  echo "######################################################################"
-  echo "Removing test for cpuutil for v12.2.2"
-  echo "######################################################################"
-
-  head -n 257 app/dynamic_policy_test.go > dynamic_policy_test.go
-  tail -n +290 app/dynamic_policy_test.go >> dynamic_policy_test.go
-  chmod 644 dynamic_policy_test.go
-  
-  mv app/dynamic_policy_test.go app/dynamic_policy_test.orig.off
-  mv dynamic_policy_test.go app/dynamic_policy_test.go
-
+if [[ "$COMPONENT_TO_TEST" = "app" ]]; then 
 
   echo "######################################################################"
   echo "Logging in and create a test org/space, IMPORTANT: bind the public_networks_egress ASG"
@@ -101,9 +88,9 @@ export GINKGO_BINARY=$PWD/ginkgo_v2_linux_amd64
 
 # Run the actual test, pick one: {broker, api, app}
 echo "######################################################################"
-echo "Running ${COMPONENT_TO_TEST} test..."
+echo "Running ${COMPONENT_TO_TEST}, skipping any test with 'cpuutil' in it..."
 echo "######################################################################"
-./bin/test ${COMPONENT_TO_TEST} #--nodes=4 #--flake-attempts=3
+./bin/test --timeout=2h --skip "cpuutil" ${COMPONENT_TO_TEST} 
 
 
 

--- a/ci/acceptance-tests.sh
+++ b/ci/acceptance-tests.sh
@@ -33,7 +33,7 @@ cat > integration_config.json <<EOF
   "health_endpoints_basic_auth_enabled": true,
 
   "autoscaler_api": "${AUTOSCALER_API}",
-  "service_offering_enabled": true
+  "service_offering_enabled": true,
 
   "cpuutil_scaling_policy_test": {
     "app_cpu_entitlement": ${APP_CPU_ENTITLEMENT}

--- a/ci/acceptance-tests.sh
+++ b/ci/acceptance-tests.sh
@@ -13,7 +13,7 @@ tar -xzf app-autoscaler-acceptance-tests.tgz
 
 cd acceptance
 
-if [ "$COMPONENT_TO_TEST" = "app"] then 
+if [ "$COMPONENT_TO_TEST" = "app"]; then 
 
 
   echo "######################################################################"

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -674,7 +674,7 @@ resources:
   type: git
   source:
     uri: https://github.com/cloud-gov/cg-deploy-autoscaler.git
-    branch: cw4 #main
+    branch: main
     paths:
     - ci/*
     - bosh/*

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -43,6 +43,8 @@ jobs:
       - app-autoscaler-release/operations/enable-scheduler-logging.yml
       - autoscaler-manifests/bosh/opsfiles/cf-uaa-client-secret-dev.yml
       - autoscaler-manifests/bosh/opsfiles/certificates.yml
+#      - autoscaler-manifests/bosh/opsfiles/route-registrar-tls.yml
+#      - app-autoscaler-release/operations/cpu_upper_threshold_400.yml
       - autoscaler-manifests/bosh/opsfiles/releases.yml
       - autoscaler-manifests/bosh/opsfiles/scaling-dev.yml
       vars_files:
@@ -97,6 +99,7 @@ jobs:
 #      CF_ADMIN_PASSWORD: ((cf.development.admin_password))
 #      AUTOSCALER_API: ((cf.development.autoscaler_api))
 #      COMPONENT_TO_TEST: broker
+#      APP_CPU_ENTITLEMENT: 50
 #
 #
 #- name: acceptance-tests-api-development-debug
@@ -115,6 +118,7 @@ jobs:
 #      CF_ADMIN_PASSWORD: ((cf.development.admin_password))
 #      AUTOSCALER_API: ((cf.development.autoscaler_api))
 #      COMPONENT_TO_TEST: api
+#      APP_CPU_ENTITLEMENT: 50
 #
 #
 #- name: acceptance-tests-app-development-debug
@@ -133,7 +137,7 @@ jobs:
 #      CF_ADMIN_PASSWORD: ((cf.development.admin_password))
 #      AUTOSCALER_API: ((cf.development.autoscaler_api))
 #      COMPONENT_TO_TEST: app
-
+#      APP_CPU_ENTITLEMENT: 50
 
 
 ## Acceptance tests for dev
@@ -155,6 +159,7 @@ jobs:
       CF_ADMIN_PASSWORD: ((cf.development.admin_password))
       AUTOSCALER_API: ((cf.development.autoscaler_api))
       COMPONENT_TO_TEST: broker
+      APP_CPU_ENTITLEMENT: 50
   on_success:
     put: slack
     params:
@@ -192,6 +197,7 @@ jobs:
       CF_ADMIN_PASSWORD: ((cf.development.admin_password))
       AUTOSCALER_API: ((cf.development.autoscaler_api))
       COMPONENT_TO_TEST: api
+      APP_CPU_ENTITLEMENT: 50
   on_success:
     put: slack
     params:
@@ -229,6 +235,7 @@ jobs:
       CF_ADMIN_PASSWORD: ((cf.development.admin_password))
       AUTOSCALER_API: ((cf.development.autoscaler_api))
       COMPONENT_TO_TEST: app
+      APP_CPU_ENTITLEMENT: 50
   on_success:
     put: slack
     params:
@@ -261,7 +268,7 @@ jobs:
       trigger: true
     - get: autoscaler-manifests
       resource: autoscaler-manifests
-      passed: [acceptance-tests-api-development, acceptance-tests-broker-development ]
+      passed: [acceptance-tests-api-development, acceptance-tests-broker-development ] #[deploy-as-development] #
       trigger: true
     - get: terraform-yaml
       resource: terraform-yaml-staging
@@ -289,6 +296,7 @@ jobs:
       - app-autoscaler-release/operations/enable-scheduler-logging.yml
       - autoscaler-manifests/bosh/opsfiles/cf-uaa-client-secret-stage.yml
       - autoscaler-manifests/bosh/opsfiles/certificates.yml
+#      - autoscaler-manifests/bosh/opsfiles/route-registrar-tls.yml
       - autoscaler-manifests/bosh/opsfiles/releases.yml
       - autoscaler-manifests/bosh/opsfiles/scaling-stage.yml
       vars_files:
@@ -345,6 +353,7 @@ jobs:
       CF_ADMIN_PASSWORD: ((cf.staging.admin_password))
       AUTOSCALER_API: ((cf.staging.autoscaler_api))
       COMPONENT_TO_TEST: broker
+      APP_CPU_ENTITLEMENT: 50
   on_success:
     put: slack
     params:
@@ -381,6 +390,7 @@ jobs:
       CF_ADMIN_PASSWORD: ((cf.staging.admin_password))
       AUTOSCALER_API: ((cf.staging.autoscaler_api))
       COMPONENT_TO_TEST: api
+      APP_CPU_ENTITLEMENT: 50
   on_success:
     put: slack
     params:
@@ -417,6 +427,7 @@ jobs:
       CF_ADMIN_PASSWORD: ((cf.staging.admin_password))
       AUTOSCALER_API: ((cf.staging.autoscaler_api))
       COMPONENT_TO_TEST: app
+      APP_CPU_ENTITLEMENT: 50
   on_success:
     put: slack
     params:
@@ -448,7 +459,7 @@ jobs:
       trigger: true
     - get: autoscaler-manifests
       resource: autoscaler-manifests
-      passed: [acceptance-tests-api-staging, acceptance-tests-broker-staging]
+      passed: [acceptance-tests-api-staging, acceptance-tests-broker-staging] #[deploy-as-staging] #
       trigger: true
     - get: terraform-yaml
       resource: terraform-yaml-production
@@ -476,6 +487,7 @@ jobs:
       - app-autoscaler-release/operations/enable-scheduler-logging.yml
       - autoscaler-manifests/bosh/opsfiles/cf-uaa-client-secret-prod.yml
       - autoscaler-manifests/bosh/opsfiles/certificates.yml
+#      - autoscaler-manifests/bosh/opsfiles/route-registrar-tls.yml
       - autoscaler-manifests/bosh/opsfiles/releases.yml
       - autoscaler-manifests/bosh/opsfiles/scaling-prod.yml
       vars_files:
@@ -532,6 +544,7 @@ jobs:
       CF_ADMIN_PASSWORD: ((cf.production.admin_password))
       AUTOSCALER_API: ((cf.production.autoscaler_api))
       COMPONENT_TO_TEST: broker
+      APP_CPU_ENTITLEMENT: 50
   on_success:
     put: slack
     params:
@@ -568,6 +581,7 @@ jobs:
       CF_ADMIN_PASSWORD: ((cf.production.admin_password))
       AUTOSCALER_API: ((cf.production.autoscaler_api))
       COMPONENT_TO_TEST: api
+      APP_CPU_ENTITLEMENT: 50
   on_success:
     put: slack
     params:
@@ -604,6 +618,7 @@ jobs:
       CF_ADMIN_PASSWORD: ((cf.production.admin_password))
       AUTOSCALER_API: ((cf.production.autoscaler_api))
       COMPONENT_TO_TEST: app
+      APP_CPU_ENTITLEMENT: 50
   on_success:
     put: slack
     params:
@@ -640,7 +655,7 @@ resources:
   type: git
   source:
     uri: https://github.com/cloud-gov/cg-deploy-autoscaler.git
-    branch: main
+    branch: cw4 #main
     paths:
     - ci/*
     - bosh/*

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -100,6 +100,8 @@ jobs:
 #      AUTOSCALER_API: ((cf.development.autoscaler_api))
 #      COMPONENT_TO_TEST: broker
 #      APP_CPU_ENTITLEMENT: 50
+#      AUTOSCALER_CF_ORG: ((cf.development.org))
+#      AUTOSCALER_CF_SPACE: ((cf.development.space))
 #
 #
 #- name: acceptance-tests-api-development-debug
@@ -119,6 +121,8 @@ jobs:
 #      AUTOSCALER_API: ((cf.development.autoscaler_api))
 #      COMPONENT_TO_TEST: api
 #      APP_CPU_ENTITLEMENT: 50
+#      AUTOSCALER_CF_ORG: ((cf.development.org))
+#      AUTOSCALER_CF_SPACE: ((cf.development.space))
 #
 #
 #- name: acceptance-tests-app-development-debug
@@ -138,7 +142,8 @@ jobs:
 #      AUTOSCALER_API: ((cf.development.autoscaler_api))
 #      COMPONENT_TO_TEST: app
 #      APP_CPU_ENTITLEMENT: 50
-
+#      AUTOSCALER_CF_ORG: ((cf.development.org))
+#      AUTOSCALER_CF_SPACE: ((cf.development.space))
 
 ## Acceptance tests for dev
 
@@ -160,6 +165,8 @@ jobs:
       AUTOSCALER_API: ((cf.development.autoscaler_api))
       COMPONENT_TO_TEST: broker
       APP_CPU_ENTITLEMENT: 50
+      AUTOSCALER_CF_ORG: ((cf.development.org))
+      AUTOSCALER_CF_SPACE: ((cf.development.space))
   on_success:
     put: slack
     params:
@@ -198,6 +205,8 @@ jobs:
       AUTOSCALER_API: ((cf.development.autoscaler_api))
       COMPONENT_TO_TEST: api
       APP_CPU_ENTITLEMENT: 50
+      AUTOSCALER_CF_ORG: ((cf.development.org))
+      AUTOSCALER_CF_SPACE: ((cf.development.space))
   on_success:
     put: slack
     params:
@@ -236,6 +245,8 @@ jobs:
       AUTOSCALER_API: ((cf.development.autoscaler_api))
       COMPONENT_TO_TEST: app
       APP_CPU_ENTITLEMENT: 50
+      AUTOSCALER_CF_ORG: ((cf.development.org))
+      AUTOSCALER_CF_SPACE: ((cf.development.space))
   on_success:
     put: slack
     params:
@@ -354,6 +365,8 @@ jobs:
       AUTOSCALER_API: ((cf.staging.autoscaler_api))
       COMPONENT_TO_TEST: broker
       APP_CPU_ENTITLEMENT: 50
+      AUTOSCALER_CF_ORG: ((cf.staging.org))
+      AUTOSCALER_CF_SPACE: ((cf.staging.space))
   on_success:
     put: slack
     params:
@@ -391,6 +404,8 @@ jobs:
       AUTOSCALER_API: ((cf.staging.autoscaler_api))
       COMPONENT_TO_TEST: api
       APP_CPU_ENTITLEMENT: 50
+      AUTOSCALER_CF_ORG: ((cf.staging.org))
+      AUTOSCALER_CF_SPACE: ((cf.staging.space))
   on_success:
     put: slack
     params:
@@ -428,6 +443,8 @@ jobs:
       AUTOSCALER_API: ((cf.staging.autoscaler_api))
       COMPONENT_TO_TEST: app
       APP_CPU_ENTITLEMENT: 50
+      AUTOSCALER_CF_ORG: ((cf.staging.org))
+      AUTOSCALER_CF_SPACE: ((cf.staging.space))
   on_success:
     put: slack
     params:
@@ -545,6 +562,8 @@ jobs:
       AUTOSCALER_API: ((cf.production.autoscaler_api))
       COMPONENT_TO_TEST: broker
       APP_CPU_ENTITLEMENT: 50
+      AUTOSCALER_CF_ORG: ((cf.production.org))
+      AUTOSCALER_CF_SPACE: ((cf.production.space))
   on_success:
     put: slack
     params:
@@ -582,6 +601,8 @@ jobs:
       AUTOSCALER_API: ((cf.production.autoscaler_api))
       COMPONENT_TO_TEST: api
       APP_CPU_ENTITLEMENT: 50
+      AUTOSCALER_CF_ORG: ((cf.production.org))
+      AUTOSCALER_CF_SPACE: ((cf.production.space))
   on_success:
     put: slack
     params:
@@ -619,6 +640,8 @@ jobs:
       AUTOSCALER_API: ((cf.production.autoscaler_api))
       COMPONENT_TO_TEST: app
       APP_CPU_ENTITLEMENT: 50
+      AUTOSCALER_CF_ORG: ((cf.production.org))
+      AUTOSCALER_CF_SPACE: ((cf.production.space))
   on_success:
     put: slack
     params:

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -97,7 +97,6 @@ jobs:
 #      CF_ADMIN_PASSWORD: ((cf.development.admin_password))
 #      AUTOSCALER_API: ((cf.development.autoscaler_api))
 #      COMPONENT_TO_TEST: broker
-#      APP_CPU_ENTITLEMENT: 50
 #      AUTOSCALER_CF_ORG: ((cf.development.org))
 #      AUTOSCALER_CF_SPACE: ((cf.development.space))
 #
@@ -118,7 +117,6 @@ jobs:
 #      CF_ADMIN_PASSWORD: ((cf.development.admin_password))
 #      AUTOSCALER_API: ((cf.development.autoscaler_api))
 #      COMPONENT_TO_TEST: api
-#      APP_CPU_ENTITLEMENT: 50
 #      AUTOSCALER_CF_ORG: ((cf.development.org))
 #      AUTOSCALER_CF_SPACE: ((cf.development.space))
 #
@@ -139,7 +137,6 @@ jobs:
 #      CF_ADMIN_PASSWORD: ((cf.development.admin_password))
 #      AUTOSCALER_API: ((cf.development.autoscaler_api))
 #      COMPONENT_TO_TEST: app
-#      APP_CPU_ENTITLEMENT: 50
 #      AUTOSCALER_CF_ORG: ((cf.development.org))
 #      AUTOSCALER_CF_SPACE: ((cf.development.space))
 
@@ -162,7 +159,6 @@ jobs:
       CF_ADMIN_PASSWORD: ((cf.development.admin_password))
       AUTOSCALER_API: ((cf.development.autoscaler_api))
       COMPONENT_TO_TEST: broker
-      APP_CPU_ENTITLEMENT: 50
       AUTOSCALER_CF_ORG: ((cf.development.org))
       AUTOSCALER_CF_SPACE: ((cf.development.space))
   on_success:
@@ -202,7 +198,6 @@ jobs:
       CF_ADMIN_PASSWORD: ((cf.development.admin_password))
       AUTOSCALER_API: ((cf.development.autoscaler_api))
       COMPONENT_TO_TEST: api
-      APP_CPU_ENTITLEMENT: 50
       AUTOSCALER_CF_ORG: ((cf.development.org))
       AUTOSCALER_CF_SPACE: ((cf.development.space))
   on_success:
@@ -242,7 +237,6 @@ jobs:
       CF_ADMIN_PASSWORD: ((cf.development.admin_password))
       AUTOSCALER_API: ((cf.development.autoscaler_api))
       COMPONENT_TO_TEST: app
-      APP_CPU_ENTITLEMENT: 50
       AUTOSCALER_CF_ORG: ((cf.development.org))
       AUTOSCALER_CF_SPACE: ((cf.development.space))
   on_success:
@@ -361,7 +355,6 @@ jobs:
       CF_ADMIN_PASSWORD: ((cf.staging.admin_password))
       AUTOSCALER_API: ((cf.staging.autoscaler_api))
       COMPONENT_TO_TEST: broker
-      APP_CPU_ENTITLEMENT: 50
       AUTOSCALER_CF_ORG: ((cf.staging.org))
       AUTOSCALER_CF_SPACE: ((cf.staging.space))
   on_success:
@@ -400,7 +393,6 @@ jobs:
       CF_ADMIN_PASSWORD: ((cf.staging.admin_password))
       AUTOSCALER_API: ((cf.staging.autoscaler_api))
       COMPONENT_TO_TEST: api
-      APP_CPU_ENTITLEMENT: 50
       AUTOSCALER_CF_ORG: ((cf.staging.org))
       AUTOSCALER_CF_SPACE: ((cf.staging.space))
   on_success:
@@ -439,7 +431,6 @@ jobs:
       CF_ADMIN_PASSWORD: ((cf.staging.admin_password))
       AUTOSCALER_API: ((cf.staging.autoscaler_api))
       COMPONENT_TO_TEST: app
-      APP_CPU_ENTITLEMENT: 50
       AUTOSCALER_CF_ORG: ((cf.staging.org))
       AUTOSCALER_CF_SPACE: ((cf.staging.space))
   on_success:
@@ -557,7 +548,6 @@ jobs:
       CF_ADMIN_PASSWORD: ((cf.production.admin_password))
       AUTOSCALER_API: ((cf.production.autoscaler_api))
       COMPONENT_TO_TEST: broker
-      APP_CPU_ENTITLEMENT: 50
       AUTOSCALER_CF_ORG: ((cf.production.org))
       AUTOSCALER_CF_SPACE: ((cf.production.space))
   on_success:
@@ -596,7 +586,6 @@ jobs:
       CF_ADMIN_PASSWORD: ((cf.production.admin_password))
       AUTOSCALER_API: ((cf.production.autoscaler_api))
       COMPONENT_TO_TEST: api
-      APP_CPU_ENTITLEMENT: 50
       AUTOSCALER_CF_ORG: ((cf.production.org))
       AUTOSCALER_CF_SPACE: ((cf.production.space))
   on_success:
@@ -635,7 +624,6 @@ jobs:
       CF_ADMIN_PASSWORD: ((cf.production.admin_password))
       AUTOSCALER_API: ((cf.production.autoscaler_api))
       COMPONENT_TO_TEST: app
-      APP_CPU_ENTITLEMENT: 50
       AUTOSCALER_CF_ORG: ((cf.production.org))
       AUTOSCALER_CF_SPACE: ((cf.production.space))
   on_success:

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -43,8 +43,6 @@ jobs:
       - app-autoscaler-release/operations/enable-scheduler-logging.yml
       - autoscaler-manifests/bosh/opsfiles/cf-uaa-client-secret-dev.yml
       - autoscaler-manifests/bosh/opsfiles/certificates.yml
-#      - autoscaler-manifests/bosh/opsfiles/route-registrar-tls.yml
-#      - app-autoscaler-release/operations/cpu_upper_threshold_400.yml
       - autoscaler-manifests/bosh/opsfiles/releases.yml
       - autoscaler-manifests/bosh/opsfiles/scaling-dev.yml
       vars_files:
@@ -279,7 +277,7 @@ jobs:
       trigger: true
     - get: autoscaler-manifests
       resource: autoscaler-manifests
-      passed: [acceptance-tests-api-development, acceptance-tests-broker-development ] #[deploy-as-development] #
+      passed: [acceptance-tests-api-development, acceptance-tests-broker-development ] 
       trigger: true
     - get: terraform-yaml
       resource: terraform-yaml-staging
@@ -307,7 +305,6 @@ jobs:
       - app-autoscaler-release/operations/enable-scheduler-logging.yml
       - autoscaler-manifests/bosh/opsfiles/cf-uaa-client-secret-stage.yml
       - autoscaler-manifests/bosh/opsfiles/certificates.yml
-#      - autoscaler-manifests/bosh/opsfiles/route-registrar-tls.yml
       - autoscaler-manifests/bosh/opsfiles/releases.yml
       - autoscaler-manifests/bosh/opsfiles/scaling-stage.yml
       vars_files:
@@ -476,7 +473,7 @@ jobs:
       trigger: true
     - get: autoscaler-manifests
       resource: autoscaler-manifests
-      passed: [acceptance-tests-api-staging, acceptance-tests-broker-staging] #[deploy-as-staging] #
+      passed: [acceptance-tests-api-staging, acceptance-tests-broker-staging] 
       trigger: true
     - get: terraform-yaml
       resource: terraform-yaml-production
@@ -504,7 +501,6 @@ jobs:
       - app-autoscaler-release/operations/enable-scheduler-logging.yml
       - autoscaler-manifests/bosh/opsfiles/cf-uaa-client-secret-prod.yml
       - autoscaler-manifests/bosh/opsfiles/certificates.yml
-#      - autoscaler-manifests/bosh/opsfiles/route-registrar-tls.yml
       - autoscaler-manifests/bosh/opsfiles/releases.yml
       - autoscaler-manifests/bosh/opsfiles/scaling-prod.yml
       vars_files:


### PR DESCRIPTION
## Changes proposed in this pull request:

- Add configuration to support custom metrics tests
- Memory override to support disk tests
- Normalized certificate generation to conform to how we do these in CF
- All tests run green in Concourse now
- Add more examples and info to README
- Part of https://github.com/cloud-gov/product/issues/2972

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

All secrets are in credhub/s3
