### PR TITLE
Remove hardcoded release version, url, sha1

### DIFF
--- a/bosh/opsfiles/releases.yml
+++ b/bosh/opsfiles/releases.yml
@@ -1,11 +1,3 @@
-#- path: /releases/name=app-autoscaler?
-#  type: replace
-#  value:
-#    name: app-autoscaler
-#    version: "12.2.2"
-#    url: "https://bosh.io/d/github.com/cloudfoundry-incubator/app-autoscaler-release?v=12.2.2"
-#    sha1: "a1fffce71219318d1fb27ec5fc3ff84e757337ed"
-
 # Not used
 - type: remove
   path: /releases/name=postgres

--- a/bosh/opsfiles/releases.yml
+++ b/bosh/opsfiles/releases.yml
@@ -1,10 +1,10 @@
-- path: /releases/name=app-autoscaler?
-  type: replace
-  value:
-    name: app-autoscaler
-    version: "12.2.2"
-    url: "https://bosh.io/d/github.com/cloudfoundry-incubator/app-autoscaler-release?v=12.2.2"
-    sha1: "a1fffce71219318d1fb27ec5fc3ff84e757337ed"
+#- path: /releases/name=app-autoscaler?
+#  type: replace
+#  value:
+#    name: app-autoscaler
+#    version: "12.2.2"
+#    url: "https://bosh.io/d/github.com/cloudfoundry-incubator/app-autoscaler-release?v=12.2.2"
+#    sha1: "a1fffce71219318d1fb27ec5fc3ff84e757337ed"
 
 # Not used
 - type: remove

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -14,6 +14,8 @@ jobs:
   plan:
   - in_parallel:
     - get: app-autoscaler-release
+    - get: release
+      trigger: true
     - get: autoscaler-manifests
       resource: autoscaler-manifests
       trigger: true
@@ -28,6 +30,8 @@ jobs:
   - put: autoscaler-deployment-development
     params: &deploy-params
       manifest: app-autoscaler-release/templates/app-autoscaler.yml
+      releases:
+      - release/app-autoscaler-v*.tgz
       stemcells:
       - cf-stemcell-jammy/*.tgz
       ops_files:
@@ -662,10 +666,16 @@ resources:
   type: git
   source:
     uri: https://github.com/cloud-gov/cg-deploy-autoscaler.git
-    branch: main
+    branch: cw5 #main
     paths:
     - ci/*
     - bosh/*
+
+- name: release
+  type: github-release
+  source:
+    owner: cloudfoundry
+    repository: app-autoscaler-release
 
 
 #- name: autoscaler-manifests-test

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -273,6 +273,9 @@ jobs:
     - get: app-autoscaler-release
       passed: [deploy-as-development]
       trigger: true
+    - get: release
+      passed: [deploy-as-development]
+      trigger: true
     - get: autoscaler-manifests
       resource: autoscaler-manifests
       passed: [acceptance-tests-api-development, acceptance-tests-broker-development ] 
@@ -288,6 +291,8 @@ jobs:
   - put: autoscaler-deployment-staging
     params: 
       manifest: app-autoscaler-release/templates/app-autoscaler.yml
+      releases:
+      - release/app-autoscaler-v*.tgz
       stemcells:
       - cf-stemcell-jammy/*.tgz
       ops_files:
@@ -466,6 +471,9 @@ jobs:
     - get: app-autoscaler-release
       passed: [deploy-as-staging]
       trigger: true
+    - get: release
+      passed: [deploy-as-staging]
+      trigger: true
     - get: autoscaler-manifests
       resource: autoscaler-manifests
       passed: [acceptance-tests-api-staging, acceptance-tests-broker-staging] 
@@ -481,6 +489,8 @@ jobs:
   - put: autoscaler-deployment-production
     params: 
       manifest: app-autoscaler-release/templates/app-autoscaler.yml
+      releases:
+      - release/app-autoscaler-v*.tgz
       stemcells:
       - cf-stemcell-jammy/*.tgz
       ops_files:
@@ -655,23 +665,23 @@ jobs:
 # Resources
 
 resources:
-- name: app-autoscaler-release
+- name: app-autoscaler-release   #Used as input for folder structure for upstream ops files
   type: git
   source:
     uri: https://github.com/cloudfoundry/app-autoscaler-release
     branch: main
     tag_filter: "v*"
 
-- name: autoscaler-manifests
+- name: autoscaler-manifests     #Used as input for folder structure for custom ops files
   type: git
   source:
     uri: https://github.com/cloud-gov/cg-deploy-autoscaler.git
-    branch: cw5 #main
+    branch: main
     paths:
     - ci/*
     - bosh/*
 
-- name: release
+- name: release                  #Used to detect when new bosh releases are cut
   type: github-release
   source:
     owner: cloudfoundry


### PR DESCRIPTION
## Changes proposed in this pull request:

- Remove hardcoded release version, url, sha1; using concourse release resource instead.
- Tested in Dev (rolled back to an older version, deleted release, redeployed, pulled in the newest release via pipeline)
- Part of https://github.com/cloud-gov/product/issues/2972

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None
