### PR TITLE
Remove last hard coding of release version for acceptance tests

### DIFF
--- a/ci/acceptance-tests.sh
+++ b/ci/acceptance-tests.sh
@@ -4,13 +4,11 @@ set -eu
 echo "######################################################################"
 echo "This is the installed go version: $(go version)"
 echo "This is the installed cf cli version: $(cf -v)"
-echo "This is the ACCEPTANCE_TESTS_VERSION version: ${ACCEPTANCE_TESTS_VERSION}"
 echo "######################################################################"
 
 # Get the tarball with the test
-wget -O app-autoscaler-acceptance-tests.tgz  https://github.com/cloudfoundry/app-autoscaler-release/releases/download/v${ACCEPTANCE_TESTS_VERSION}/app-autoscaler-acceptance-tests-v${ACCEPTANCE_TESTS_VERSION}.tgz
-tar -xzf app-autoscaler-acceptance-tests.tgz 
-
+cd release
+tar -xzf app-autoscaler-acceptance*.tgz
 cd acceptance
 
 if [[ "$COMPONENT_TO_TEST" = "app" ]]; then 

--- a/ci/acceptance-tests.yml
+++ b/ci/acceptance-tests.yml
@@ -12,6 +12,7 @@ image_resource:
 
 inputs:
 - name: autoscaler-manifests
+- name: release
 outputs:
 - name: acceptance-tests-output      #Placeholder, not sure if needed yet
 

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -153,6 +153,9 @@ jobs:
     - get: autoscaler-manifests
       trigger: true
       passed: [deploy-as-development]
+    - get: release
+      passed: [deploy-as-development]
+      trigger: true
   - task: acceptance-tests
     file: autoscaler-manifests/ci/acceptance-tests.yml
     params:
@@ -192,6 +195,9 @@ jobs:
     - get: autoscaler-manifests
       trigger: true
       passed: [deploy-as-development] 
+    - get: release
+      passed: [deploy-as-development]
+      trigger: true
   - task: acceptance-tests
     file: autoscaler-manifests/ci/acceptance-tests.yml
     params:
@@ -231,6 +237,9 @@ jobs:
     - get: autoscaler-manifests
       trigger: true
       passed: [deploy-as-development] 
+    - get: release
+      passed: [deploy-as-development]
+      trigger: true
   - task: acceptance-tests
     file: autoscaler-manifests/ci/acceptance-tests.yml
     params:
@@ -354,6 +363,9 @@ jobs:
     - get: autoscaler-manifests
       trigger: true
       passed: [deploy-as-staging]
+    - get: release
+      passed: [deploy-as-staging]
+      trigger: true
   - task: acceptance-tests
     file: autoscaler-manifests/ci/acceptance-tests.yml
     params:
@@ -392,6 +404,9 @@ jobs:
     - get: autoscaler-manifests
       trigger: true
       passed: [deploy-as-staging] 
+    - get: release
+      passed: [deploy-as-staging]
+      trigger: true
   - task: acceptance-tests
     file: autoscaler-manifests/ci/acceptance-tests.yml
     params:
@@ -430,6 +445,9 @@ jobs:
     - get: autoscaler-manifests
       trigger: true
       passed: [deploy-as-staging] 
+    - get: release
+      passed: [deploy-as-staging]
+      trigger: true
   - task: acceptance-tests
     file: autoscaler-manifests/ci/acceptance-tests.yml
     params:
@@ -552,6 +570,9 @@ jobs:
     - get: autoscaler-manifests
       trigger: true
       passed: [deploy-as-production]
+    - get: release
+      passed: [deploy-as-production]
+      trigger: true
   - task: acceptance-tests
     file: autoscaler-manifests/ci/acceptance-tests.yml
     params:
@@ -590,6 +611,9 @@ jobs:
     - get: autoscaler-manifests
       trigger: true
       passed: [deploy-as-production] 
+    - get: release
+      passed: [deploy-as-production]
+      trigger: true
   - task: acceptance-tests
     file: autoscaler-manifests/ci/acceptance-tests.yml
     params:
@@ -628,6 +652,9 @@ jobs:
     - get: autoscaler-manifests
       trigger: true
       passed: [deploy-as-production] 
+    - get: release
+      passed: [deploy-as-production]
+      trigger: true
   - task: acceptance-tests
     file: autoscaler-manifests/ci/acceptance-tests.yml
     params:
@@ -676,7 +703,7 @@ resources:
   type: git
   source:
     uri: https://github.com/cloud-gov/cg-deploy-autoscaler.git
-    branch: main
+    branch: cw6 #main
     paths:
     - ci/*
     - bosh/*

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -703,7 +703,7 @@ resources:
   type: git
   source:
     uri: https://github.com/cloud-gov/cg-deploy-autoscaler.git
-    branch: cw6 #main
+    branch: main
     paths:
     - ci/*
     - bosh/*


### PR DESCRIPTION
## Changes proposed in this pull request:

- Remove last hard coding of release version for acceptance tests
- Acceptance tests will now match the release version deployed automatically
- Caching the tests tarball, reducing the number of times pulling the tarball back from github
- Part of https://github.com/cloud-gov/product/issues/2972

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None
