### PR TITLE
Switch pipeline secrets to only use credhub

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,16 +188,20 @@ There are two ways of enabling service access: via the pipeline and manually:
 
 ### Enable via the pipeline (Preferred)
 
-The pipeline uses [https://github.com/cloud-gov/cg-pipeline-tasks/blob/main/set-plan-visibility.yml](https://github.com/cloud-gov/cg-pipeline-tasks/blob/main/set-plan-visibility.yml) to set the list of orgs to enable the broker access.  To add additional organizations, modify the `cg-deploy-autoscaler.yml` secrets file, the list of orgs are space delimited: 
+The pipeline uses [https://github.com/cloud-gov/cg-pipeline-tasks/blob/main/set-plan-visibility.yml](https://github.com/cloud-gov/cg-pipeline-tasks/blob/main/set-plan-visibility.yml) to set the list of orgs to enable the broker access.  There are credhub variables for each of the environments which are space delimited. To  To add additional organizations, modify the following credhub variables: 
 
 ```
-cf:
-  development:
-    service_organization: org1 org2 org3
-  staging:
-    service_organization: org1 org2
-  production:
-    service_organization: org3 org4 org5
+- name: service_organization_development
+  type: value
+  value: org1 org2
+
+- name: service_organization_staging
+  type: value
+  value: org2 org3
+
+- name: service_organization_production
+  type: value
+  value: org1 org2 org3
 ```
 
 ### Manual enabling (Debugging)
@@ -505,3 +509,4 @@ In no particular order:
  - The defaults for data retentions for metrics history, scaling history and others are kept at the defaults defined in the spec, an example of this can be seen [here](https://github.com/cloudfoundry/app-autoscaler-release/blob/main/jobs/operator/spec#L215-L217).
  - Policies with recurring or date schedules still require scaling rules with a metric type defined.  If you want to force an app to scale at a particular make sure that the scaling rules are easy to achieve (ie: cpu > 0)
  - The dynamic_policy_test.go tests for disk will fail with the default 128MB of memory in Staging and Production (oddly works fine in development), this was bumped in the configuration file to 1024 MB for the `app` tests
+ - All pipeline secrets are stored in credhub, the s3 file is no longer used.

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -56,13 +56,13 @@ jobs:
     file: pipeline-tasks/set-plan-visibility.yml
     params:
       CF_API_URL: ((cf.development.api))
-      CF_USERNAME: ((cf.development.admin_user))
-      CF_PASSWORD: ((cf.development.admin_password))
+      CF_USERNAME: ((admin_user_development))
+      CF_PASSWORD: ((admin_password_development))
       CF_ORGANIZATION: ((broker-organization))
       CF_SPACE: ((broker-space))
       BROKER_NAME: ((broker-name))
       SERVICES: ((cf.development.services))
-      SERVICE_ORGANIZATION: ((cf.development.service_organization))
+      SERVICE_ORGANIZATION: ((service_organization_development))
   on_success:
     put: slack
     params:
@@ -96,8 +96,8 @@ jobs:
 #    params:
 #      CF_API: ((cf.development.api))
 #      CF_APPS_DOMAIN: ((cf.development.apps_domain))
-#      CF_ADMIN_USER: ((cf.development.admin_user))
-#      CF_ADMIN_PASSWORD: ((cf.development.admin_password))
+#      CF_ADMIN_USER: ((admin_user_development))
+#      CF_ADMIN_PASSWORD: ((admin_password_development))
 #      AUTOSCALER_API: ((cf.development.autoscaler_api))
 #      COMPONENT_TO_TEST: broker
 #      AUTOSCALER_CF_ORG: ((cf.development.org))
@@ -115,8 +115,8 @@ jobs:
 #    params:
 #      CF_API: ((cf.development.api))
 #      CF_APPS_DOMAIN: ((cf.development.apps_domain))
-#      CF_ADMIN_USER: ((cf.development.admin_user))
-#      CF_ADMIN_PASSWORD: ((cf.development.admin_password))
+#      CF_ADMIN_USER: ((admin_user_development))
+#      CF_ADMIN_PASSWORD: ((admin_password_development))
 #      AUTOSCALER_API: ((cf.development.autoscaler_api))
 #      COMPONENT_TO_TEST: api
 #      AUTOSCALER_CF_ORG: ((cf.development.org))
@@ -134,8 +134,8 @@ jobs:
 #    params:
 #      CF_API: ((cf.development.api))
 #      CF_APPS_DOMAIN: ((cf.development.apps_domain))
-#      CF_ADMIN_USER: ((cf.development.admin_user))
-#      CF_ADMIN_PASSWORD: ((cf.development.admin_password))
+#      CF_ADMIN_USER: ((admin_user_development))
+#      CF_ADMIN_PASSWORD: ((admin_password_development))
 #      AUTOSCALER_API: ((cf.development.autoscaler_api))
 #      COMPONENT_TO_TEST: app
 #      AUTOSCALER_CF_ORG: ((cf.development.org))
@@ -158,8 +158,8 @@ jobs:
     params:
       CF_API: ((cf.development.api))
       CF_APPS_DOMAIN: ((cf.development.apps_domain))
-      CF_ADMIN_USER: ((cf.development.admin_user))
-      CF_ADMIN_PASSWORD: ((cf.development.admin_password))
+      CF_ADMIN_USER: ((admin_user_development))
+      CF_ADMIN_PASSWORD: ((admin_password_development))
       AUTOSCALER_API: ((cf.development.autoscaler_api))
       COMPONENT_TO_TEST: broker
       AUTOSCALER_CF_ORG: ((cf.development.org))
@@ -199,8 +199,8 @@ jobs:
     params:
       CF_API: ((cf.development.api))
       CF_APPS_DOMAIN: ((cf.development.apps_domain))
-      CF_ADMIN_USER: ((cf.development.admin_user))
-      CF_ADMIN_PASSWORD: ((cf.development.admin_password))
+      CF_ADMIN_USER: ((admin_user_development))
+      CF_ADMIN_PASSWORD: ((admin_password_development))
       AUTOSCALER_API: ((cf.development.autoscaler_api))
       COMPONENT_TO_TEST: api
       AUTOSCALER_CF_ORG: ((cf.development.org))
@@ -240,8 +240,8 @@ jobs:
     params:
       CF_API: ((cf.development.api))
       CF_APPS_DOMAIN: ((cf.development.apps_domain))
-      CF_ADMIN_USER: ((cf.development.admin_user))
-      CF_ADMIN_PASSWORD: ((cf.development.admin_password))
+      CF_ADMIN_USER: ((admin_user_development))
+      CF_ADMIN_PASSWORD: ((admin_password_development))
       AUTOSCALER_API: ((cf.development.autoscaler_api))
       COMPONENT_TO_TEST: app
       AUTOSCALER_CF_ORG: ((cf.development.org))
@@ -320,13 +320,13 @@ jobs:
     file: pipeline-tasks/set-plan-visibility.yml
     params:
       CF_API_URL: ((cf.staging.api))
-      CF_USERNAME: ((cf.staging.admin_user))
-      CF_PASSWORD: ((cf.staging.admin_password))
+      CF_USERNAME: ((admin_user_staging))
+      CF_PASSWORD: ((admin_password_staging))
       CF_ORGANIZATION: ((broker-organization))
       CF_SPACE: ((broker-space))
       BROKER_NAME: ((broker-name))
       SERVICES: ((cf.staging.services))
-      SERVICE_ORGANIZATION: ((cf.staging.service_organization))
+      SERVICE_ORGANIZATION: ((service_organization_staging))
   on_success:
     put: slack
     params:
@@ -365,8 +365,8 @@ jobs:
     params:
       CF_API: ((cf.staging.api))
       CF_APPS_DOMAIN: ((cf.staging.apps_domain))
-      CF_ADMIN_USER: ((cf.staging.admin_user))
-      CF_ADMIN_PASSWORD: ((cf.staging.admin_password))
+      CF_ADMIN_USER: ((admin_user_staging))
+      CF_ADMIN_PASSWORD: ((admin_password_staging))
       AUTOSCALER_API: ((cf.staging.autoscaler_api))
       COMPONENT_TO_TEST: broker
       AUTOSCALER_CF_ORG: ((cf.staging.org))
@@ -405,8 +405,8 @@ jobs:
     params:
       CF_API: ((cf.staging.api))
       CF_APPS_DOMAIN: ((cf.staging.apps_domain))
-      CF_ADMIN_USER: ((cf.staging.admin_user))
-      CF_ADMIN_PASSWORD: ((cf.staging.admin_password))
+      CF_ADMIN_USER: ((admin_user_staging))
+      CF_ADMIN_PASSWORD: ((admin_password_staging))
       AUTOSCALER_API: ((cf.staging.autoscaler_api))
       COMPONENT_TO_TEST: api
       AUTOSCALER_CF_ORG: ((cf.staging.org))
@@ -445,8 +445,8 @@ jobs:
     params:
       CF_API: ((cf.staging.api))
       CF_APPS_DOMAIN: ((cf.staging.apps_domain))
-      CF_ADMIN_USER: ((cf.staging.admin_user))
-      CF_ADMIN_PASSWORD: ((cf.staging.admin_password))
+      CF_ADMIN_USER: ((admin_user_staging))
+      CF_ADMIN_PASSWORD: ((admin_password_staging))
       AUTOSCALER_API: ((cf.staging.autoscaler_api))
       COMPONENT_TO_TEST: app
       AUTOSCALER_CF_ORG: ((cf.staging.org))
@@ -524,13 +524,13 @@ jobs:
     file: pipeline-tasks/set-plan-visibility.yml
     params:
       CF_API_URL: ((cf.production.api))
-      CF_USERNAME: ((cf.production.admin_user))
-      CF_PASSWORD: ((cf.production.admin_password))
+      CF_USERNAME: ((admin_user_production))
+      CF_PASSWORD: ((admin_password_production))
       CF_ORGANIZATION: ((broker-organization))
       CF_SPACE: ((broker-space))
       BROKER_NAME: ((broker-name))
       SERVICES: ((cf.production.services))
-      SERVICE_ORGANIZATION: ((cf.production.service_organization))
+      SERVICE_ORGANIZATION: ((service_organization_production))
   on_success:
     put: slack
     params:
@@ -569,8 +569,8 @@ jobs:
     params:
       CF_API: ((cf.production.api))
       CF_APPS_DOMAIN: ((cf.production.apps_domain))
-      CF_ADMIN_USER: ((cf.production.admin_user))
-      CF_ADMIN_PASSWORD: ((cf.production.admin_password))
+      CF_ADMIN_USER: ((admin_user_production))
+      CF_ADMIN_PASSWORD: ((admin_password_production))
       AUTOSCALER_API: ((cf.production.autoscaler_api))
       COMPONENT_TO_TEST: broker
       AUTOSCALER_CF_ORG: ((cf.production.org))
@@ -609,8 +609,8 @@ jobs:
     params:
       CF_API: ((cf.production.api))
       CF_APPS_DOMAIN: ((cf.production.apps_domain))
-      CF_ADMIN_USER: ((cf.production.admin_user))
-      CF_ADMIN_PASSWORD: ((cf.production.admin_password))
+      CF_ADMIN_USER: ((admin_user_production))
+      CF_ADMIN_PASSWORD: ((admin_password_production))
       AUTOSCALER_API: ((cf.production.autoscaler_api))
       COMPONENT_TO_TEST: api
       AUTOSCALER_CF_ORG: ((cf.production.org))
@@ -649,8 +649,8 @@ jobs:
     params:
       CF_API: ((cf.production.api))
       CF_APPS_DOMAIN: ((cf.production.apps_domain))
-      CF_ADMIN_USER: ((cf.production.admin_user))
-      CF_ADMIN_PASSWORD: ((cf.production.admin_password))
+      CF_ADMIN_USER: ((admin_user_production))
+      CF_ADMIN_PASSWORD: ((admin_password_production))
       AUTOSCALER_API: ((cf.production.autoscaler_api))
       COMPONENT_TO_TEST: app
       AUTOSCALER_CF_ORG: ((cf.production.org))
@@ -753,29 +753,29 @@ resources:
 - name: autoscaler-deployment-development
   type: bosh-deployment
   source:
-    target: ((bosh.development.environment))
-    client: ((bosh.development.client))
-    client_secret: ((bosh.development.client-secret))
-    ca_cert: ((bosh-ca-cert))
+    target: ((bosh-director-info.development.environment))
+    client: ((bosh-director-info.development.client))
+    client_secret: ((bosh-director-info.development.client_secret))
+    ca_cert: ((bosh-director-info.development.ca_cert))
     deployment: app-autoscaler
 
 
 - name: autoscaler-deployment-staging
   type: bosh-deployment
   source:
-    target: ((bosh.staging.environment))
-    client: ((bosh.staging.client))
-    client_secret: ((bosh.staging.client-secret))
-    ca_cert: ((bosh-ca-cert))
+    target: ((bosh-director-info.staging.environment))
+    client: ((bosh-director-info.staging.client))
+    client_secret: ((bosh-director-info.staging.client_secret))
+    ca_cert: ((bosh-director-info.staging.ca_cert))
     deployment: app-autoscaler
 
 - name: autoscaler-deployment-production
   type: bosh-deployment
   source:
-    target: ((bosh.production.environment))
-    client: ((bosh.production.client))
-    client_secret: ((bosh.production.client-secret))
-    ca_cert: ((bosh-ca-cert))
+    target: ((bosh-director-info.production.environment))
+    client: ((bosh-director-info.production.client))
+    client_secret: ((bosh-director-info.production.client-secret))
+    ca_cert: ((bosh-director-info.production.ca_cert))
     deployment: app-autoscaler
 
 - name: slack


### PR DESCRIPTION
## Changes proposed in this pull request:

- Switch App-AutoScaler pipeline secrets to only use credhub, removing the secrets file from s3
- Part of https://github.com/cloud-gov/private/issues/618
-

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

One less set of creds managed in s3, a bunch more to go...
