### PR TITLE
Set pipeline to self-fly

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -8,6 +8,14 @@
 # Deploy Development
 
 jobs:
+
+- name: set-self
+  plan:
+    - get: autoscaler-manifests
+      resource: autoscaler-manifests
+      trigger: true
+    - set_pipeline: self
+      file: autoscaler-manifests/ci/pipeline.yml
 - name: deploy-app-autoscaler-development
   serial: true
   serial_groups: [development]
@@ -19,6 +27,7 @@ jobs:
     - get: autoscaler-manifests
       resource: autoscaler-manifests
       trigger: true
+      passed: [set-self]
     - get: terraform-yaml
       resource: terraform-yaml-development
       trigger: true


### PR DESCRIPTION
## Changes proposed in this pull request:

- Make pipeline be self setting
- All variables are already in credhub
-

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

All secrets are already in credhub
