### PR TITLE
Turn off dev after hours

### DIFF
--- a/ci/delete-deployment.sh
+++ b/ci/delete-deployment.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -eu
+
+echo "Tearing down..."
+
+bosh -n delete-deployment app-autoscaler

--- a/ci/delete-deployment.yml
+++ b/ci/delete-deployment.yml
@@ -1,0 +1,26 @@
+---
+platform: linux
+
+image_resource:
+  type: registry-image
+  source:
+    aws_access_key_id: ((ecr_aws_key))
+    aws_secret_access_key: ((ecr_aws_secret))
+    repository: general-task
+    aws_region: us-gov-west-1
+    tag: latest   
+
+inputs:
+- name: autoscaler-manifests
+- name: release
+
+
+run:
+  path: autoscaler-manifests/ci/delete-deployment.sh
+
+params:
+  BOSH_CA_CERT:
+  BOSH_ENVIRONMENT:
+  BOSH_CLIENT:
+  BOSH_CLIENT_SECRET:
+  BOSH_ENV_NAME:

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -88,6 +88,23 @@ jobs:
       username: ((slack-username))
       icon_url: ((slack-icon-url))
 
+- name: delete-dev-after-hours
+  plan:
+  - in_parallel:
+    - get: after-hours
+      trigger: true
+    - get: autoscaler-manifests
+      passed: [deploy-app-autoscaler-development]
+    - get: release
+      passed: [deploy-app-autoscaler-development]
+  - task: delete-deployment
+    file: autoscaler-manifests/ci/delete-deployment.yml
+    params:
+      BOSH_CA_CERT: ((bosh-director-info.development.ca_cert))
+      BOSH_ENVIRONMENT: ((bosh-director-info.development.environment))
+      BOSH_CLIENT: ((bosh-director-info.development.client))
+      BOSH_CLIENT_SECRET: ((bosh-director-info.development.client_secret))
+      BOSH_ENV_NAME: development
 
 ## Enable these 3 to more quickly debug changes to acceptance-tests.sh, bypasses the need to first deploy autoscaler to dev
 
@@ -782,6 +799,16 @@ resources:
   type: slack-notification
   source:
     url: ((slack-webhook-url))
+
+
+- name: after-hours
+  type: time
+  source:
+    start: 6:00 PM
+    stop: 7:00 PM
+    location: America/Los_Angeles
+
+
 
 resource_types:
 - name: registry-image


### PR DESCRIPTION
## Changes proposed in this pull request:

- Experimental: looking to "turn off" a deployment in after-hours.
- If a stemcell or release drops, it will spin back up.  If nothing auto-triggers, the humans can click the deploy button to spin it back up
- Used a west coast time zone as the basis of when to spin down.
- Part of IP sprint
- Save $$$ hopefully.  If this works well, maybe look at other deployments, obviously not production (ever!)

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the output, which can prevent unintentional leaks of sensitive data.

## Security considerations

None.  Picked a non-vital deployment to play with
