### PR TITLE
Deploy and delete should not happen at the same time

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -89,6 +89,8 @@ jobs:
       icon_url: ((slack-icon-url))
 
 - name: delete-dev-after-hours
+  serial: true
+  serial_groups: [development]
   plan:
   - in_parallel:
     - get: after-hours


### PR DESCRIPTION
## Changes proposed in this pull request:

- Deploy and delete should not happen at the same time, don't upset bosh
-
-

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None
