### PR TITLE
Turn off staging after hours

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -368,7 +368,25 @@ jobs:
       username: ((slack-username))
       icon_url: ((slack-icon-url))
 
-
+- name: delete-staging-after-hours
+  serial: true
+  serial_groups: [staging]
+  plan:
+  - in_parallel:
+    - get: after-hours
+      trigger: true
+    - get: autoscaler-manifests
+      passed: [deploy-app-autoscaler-staging]
+    - get: release
+      passed: [deploy-app-autoscaler-staging]
+  - task: delete-deployment
+    file: autoscaler-manifests/ci/delete-deployment.yml
+    params:
+      BOSH_CA_CERT: ((bosh-director-info.staging.ca_cert))
+      BOSH_ENVIRONMENT: ((bosh-director-info.staging.environment))
+      BOSH_CLIENT: ((bosh-director-info.staging.client))
+      BOSH_CLIENT_SECRET: ((bosh-director-info.staging.client_secret))
+      BOSH_ENV_NAME: staging
 
 ## Acceptance tests for Staging
 


### PR DESCRIPTION
## Changes proposed in this pull request:

- This is a similar change as the previous PR, it adds a timer and job that turns staging off after 6PM PT.
- A stemcell update, release update or changes to the pipeline will trigger the environment to turn back on, this is a desired behavior.  If needed, can add a "turn on" timer that triggers the "deploy-<env>" which will redeploy the environment
- Save more $$$ on EC2 costs.  As long as the RDS db that backs the deployment is left alone, the deployment can remain turned off indefinitely but no scaling events will occur.

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None
