### PR TITLE
Halt github api throttling

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -738,7 +738,7 @@ resources:
   source:
     owner: cloudfoundry
     repository: app-autoscaler-release
-
+    access_token: ((github-access-token))
 
 #- name: autoscaler-manifests-test
 #  type: git


### PR DESCRIPTION
## Changes proposed in this pull request:

- Tired of getting:

> error running command: GET https://api.github.com/repos/cloudfoundry/app-autoscaler-release/releases/assets/198385215: 403 API rate limit exceeded for x.x.x.x. (But here's the good news: Authenticated requests get a higher rate limit. Check out the documentation for more details.) [rate reset in 23m17s]
- Hoping this fixes it
- Part of https://github.com/cloud-gov/private/issues/618

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None that I can think of, the check would use an authenticated token to hopefully not get throttled, the repo itself is not owned by Cloud.gov
