### PR TITLE
Put the tar back

### DIFF
--- a/ci/acceptance-tests.sh
+++ b/ci/acceptance-tests.sh
@@ -8,6 +8,8 @@ echo "######################################################################"
 
 # Get the tarball with the test
 cd release
+tar -xzf app-autoscaler-acceptance*.tgz
+cd acceptance
 
 if [[ "$COMPONENT_TO_TEST" = "app" ]]; then 
 


### PR DESCRIPTION
## Changes proposed in this pull request:

- Removed too many lines from cleanup of v14 tests in https://github.com/cloud-gov/deploy-autoscaler/pull/39
- It happens
- Part of https://github.com/cloud-gov/product/issues/2836

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Put the tar back, no security concerns
