### PR TITLE
Rewire acceptance tests

### DIFF
--- a/ci/acceptance-tests.sh
+++ b/ci/acceptance-tests.sh
@@ -6,8 +6,9 @@ echo "This is the installed go version: $(go version)"
 echo "This is the installed cf cli version: $(cf -v)"
 echo "######################################################################"
 
-# Get the repo with the tests
-cd autoscaler-acceptance
+# Get the tarball with the test
+cd autoscaler-acceptance #release
+tar -xzf app-autoscaler-acceptance*.tgz
 cd acceptance
 
 if [[ "$COMPONENT_TO_TEST" = "app" ]]; then 
@@ -82,7 +83,7 @@ fi
 export CONFIG=$PWD/integration_config.json
 
 # Set GINKGO_BINARY since its provided in the tarball, omit this to have it built at runtime
-# export GINKGO_BINARY=$PWD/ginkgo_v2_linux_amd64  #No longer provided in the tarball, using built-in ginkgo instead
+export GINKGO_BINARY=$PWD/ginkgo_v2_linux_amd64
 
 
 # Run the actual test, pick one: {broker, api, app}

--- a/ci/acceptance-tests.sh
+++ b/ci/acceptance-tests.sh
@@ -82,7 +82,7 @@ fi
 export CONFIG=$PWD/integration_config.json
 
 # Set GINKGO_BINARY since its provided in the tarball, omit this to have it built at runtime
-export GINKGO_BINARY=$PWD/ginkgo_v2_linux_amd64
+# export GINKGO_BINARY=$PWD/ginkgo_v2_linux_amd64  #No longer provided in the tarball, using built-in ginkgo instead
 
 
 # Run the actual test, pick one: {broker, api, app}

--- a/ci/acceptance-tests.sh
+++ b/ci/acceptance-tests.sh
@@ -7,7 +7,7 @@ echo "This is the installed cf cli version: $(cf -v)"
 echo "######################################################################"
 
 # Get the tarball with the test
-cd autoscaler-acceptance #release
+cd autoscaler-acceptance
 tar -xzf app-autoscaler-acceptance*.tgz
 cd acceptance
 

--- a/ci/acceptance-tests.sh
+++ b/ci/acceptance-tests.sh
@@ -6,9 +6,8 @@ echo "This is the installed go version: $(go version)"
 echo "This is the installed cf cli version: $(cf -v)"
 echo "######################################################################"
 
-# Get the tarball with the test
-cd release
-tar -xzf app-autoscaler-acceptance*.tgz
+# Get the repo with the tests
+cd autoscaler-acceptance
 cd acceptance
 
 if [[ "$COMPONENT_TO_TEST" = "app" ]]; then 

--- a/ci/acceptance-tests.sh
+++ b/ci/acceptance-tests.sh
@@ -78,20 +78,35 @@ else
 EOF
 fi
 
-
-
 export CONFIG=$PWD/integration_config.json
 
-# Set GINKGO_BINARY since its provided in the tarball, omit this to have it built at runtime
-export GINKGO_BINARY=$PWD/ginkgo_v2_linux_amd64
-
-
-# Run the actual test, pick one: {broker, api, app}
 echo "######################################################################"
 echo "Running ${COMPONENT_TO_TEST}, skip 4 test with 'disable', 'mtls' or 'lead' in it..."
 echo "######################################################################"
-./bin/test --timeout=2h --skip "disable"  --skip "mtls" --skip "lead" ${COMPONENT_TO_TEST} 
 
+case $COMPONENT_TO_TEST in
+  "api")
+       echo "Running API tests"
+       cd api
+       ./api_linux_amd64.test
+       break
+       ;;
+   "app")
+       echo "Running App tests"
+       cd app
+       ./app_linux_amd64.test --ginkgo.timeout 2h --ginkgo.skip "disable"  --ginkgo.skip "mtls" --ginkgo.skip "lead"
+       break
+       ;;
+   "broker")
+       echo "Running Broker tests"
+       cd broker
+       ./broker_linux_amd64.test 
+       break
+       ;;
+   *) echo "Invalid selection $COMPONENT_TO_TEST";;
+esac
+
+cd ..
 
 
 # Perform the cleanup (drops any created org that is named ASATS*)

--- a/ci/acceptance-tests.yml
+++ b/ci/acceptance-tests.yml
@@ -12,6 +12,7 @@ image_resource:
 
 inputs:
 - name: autoscaler-manifests
+- name: autoscaler-acceptance
 - name: release
 outputs:
 - name: acceptance-tests-output      #Placeholder, not sure if needed yet

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -13,8 +13,8 @@ jobs:
     - get: autoscaler-manifests
       resource: autoscaler-manifests
       trigger: true
-#    - set_pipeline: self
-#      file: autoscaler-manifests/ci/pipeline.yml
+    - set_pipeline: self
+      file: autoscaler-manifests/ci/pipeline.yml
 - name: deploy-app-autoscaler-development
   serial: true
   serial_groups: [development]
@@ -126,13 +126,6 @@ jobs:
       COMPONENT_TO_TEST: broker
       AUTOSCALER_CF_ORG: ((cf.development.org))
       AUTOSCALER_CF_SPACE: ((cf.development.space))
-#  on_failure:
-#    put: slack
-#    params:
-#      <<: *slack-failure-params
-#      text: |
-#        :x: FAILED testing the broker component of CF App Autoscaler on development
-#        <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
 
 
 - name: acceptance-tests-api-development
@@ -159,14 +152,6 @@ jobs:
       COMPONENT_TO_TEST: api
       AUTOSCALER_CF_ORG: ((cf.development.org))
       AUTOSCALER_CF_SPACE: ((cf.development.space))
-#  on_failure:
-#    put: slack
-#    params:
-#      <<: *slack-failure-params
-#      text: |
-#        :x: FAILED testing the api component of CF App Autoscaler on development
-#        <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
-
 
 - name: acceptance-tests-app-development
   serial_groups: [development]
@@ -192,13 +177,6 @@ jobs:
       COMPONENT_TO_TEST: app
       AUTOSCALER_CF_ORG: ((cf.development.org))
       AUTOSCALER_CF_SPACE: ((cf.development.space))
-#  on_failure:
-#    put: slack
-#    params:
-#      <<: *slack-failure-params
-#      text: |
-#        :x: FAILED testing the app component of CF App Autoscaler on development
-#        <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
 
 
 # Deploy Staging
@@ -588,13 +566,6 @@ resources:
     owner: cloudfoundry
     repository: app-autoscaler
     access_token: ((github-access-token))
-
-#  type: git
-#  source:
-#    uri: https://github.com/cloudfoundry/app-autoscaler
-#    branch: main
-#    tag_filter: "v*"
-
 
 - name: release                  #Used to detect when new bosh releases are cut
   type: github-release

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -583,11 +583,17 @@ resources:
     - bosh/*
 
 - name: autoscaler-acceptance     #Repo with acceptance tests
-  type: git
+  type: github-release
   source:
-    uri: https://github.com/cloudfoundry/app-autoscaler
-    branch: main
-    tag_filter: "v*"
+    owner: cloudfoundry
+    repository: app-autoscaler
+    access_token: ((github-access-token))
+
+#  type: git
+#  source:
+#    uri: https://github.com/cloudfoundry/app-autoscaler
+#    branch: main
+#    tag_filter: "v*"
 
 
 - name: release                  #Used to detect when new bosh releases are cut

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -3,7 +3,6 @@
 # Notes:
 # - Do not run the acceptance tests in parallel, there is a cleanup.sh script which will conflict with other runs in parallel, serial_groups are the enforcement of this
 # - As of now, the "app" acceptance tests fail on custom metrics.  Downstream deploys are explicitly not dependent on the app tests to pass for now.
-# - The three "*-debug" jobs can be commented out once autoscaler is in normal operating mode, these exist to shorten the test cycle of debugging the acceptance tests against dev
 
 # Deploy Development
 
@@ -14,8 +13,8 @@ jobs:
     - get: autoscaler-manifests
       resource: autoscaler-manifests
       trigger: true
-    - set_pipeline: self
-      file: autoscaler-manifests/ci/pipeline.yml
+#    - set_pipeline: self
+#      file: autoscaler-manifests/ci/pipeline.yml
 - name: deploy-app-autoscaler-development
   serial: true
   serial_groups: [development]
@@ -99,63 +98,6 @@ jobs:
       BOSH_CLIENT_SECRET: ((bosh-director-info.development.client_secret))
       BOSH_ENV_NAME: development
 
-## Enable these 3 to more quickly debug changes to acceptance-tests.sh, bypasses the need to first deploy autoscaler to dev
-
-#- name: acceptance-tests-broker-development-debug
-#  serial_groups: [development, debug]
-#  plan:
-#  - in_parallel:
-#    - get: autoscaler-manifests-test                               #Modified resource to do testing
-#      trigger: true
-#  - task: acceptance-tests
-#    file: autoscaler-manifests-test/ci/acceptance-tests-debug.yml  #Modified resource to do testing
-#    params:
-#      CF_API: ((cf.development.api))
-#      CF_APPS_DOMAIN: ((cf.development.apps_domain))
-#      CF_ADMIN_USER: ((admin_user_development))
-#      CF_ADMIN_PASSWORD: ((admin_password_development))
-#      AUTOSCALER_API: ((cf.development.autoscaler_api))
-#      COMPONENT_TO_TEST: broker
-#      AUTOSCALER_CF_ORG: ((cf.development.org))
-#      AUTOSCALER_CF_SPACE: ((cf.development.space))
-#
-#
-#- name: acceptance-tests-api-development-debug
-#  serial_groups: [development, debug]
-#  plan:
-#  - in_parallel:
-#    - get: autoscaler-manifests-test                               #Modified resource to do testing
-#      trigger: true
-#  - task: acceptance-tests
-#    file: autoscaler-manifests-test/ci/acceptance-tests-debug.yml  #Modified resource to do testing
-#    params:
-#      CF_API: ((cf.development.api))
-#      CF_APPS_DOMAIN: ((cf.development.apps_domain))
-#      CF_ADMIN_USER: ((admin_user_development))
-#      CF_ADMIN_PASSWORD: ((admin_password_development))
-#      AUTOSCALER_API: ((cf.development.autoscaler_api))
-#      COMPONENT_TO_TEST: api
-#      AUTOSCALER_CF_ORG: ((cf.development.org))
-#      AUTOSCALER_CF_SPACE: ((cf.development.space))
-#
-#
-#- name: acceptance-tests-app-development-debug
-#  serial_groups: [development, debug]
-#  plan:
-#  - in_parallel:
-#    - get: autoscaler-manifests-test                               #Modified resource to do testing
-#      trigger: true
-#  - task: acceptance-tests
-#    file: autoscaler-manifests-test/ci/acceptance-tests-debug.yml  #Modified resource to do testing
-#    params:
-#      CF_API: ((cf.development.api))
-#      CF_APPS_DOMAIN: ((cf.development.apps_domain))
-#      CF_ADMIN_USER: ((admin_user_development))
-#      CF_ADMIN_PASSWORD: ((admin_password_development))
-#      AUTOSCALER_API: ((cf.development.autoscaler_api))
-#      COMPONENT_TO_TEST: app
-#      AUTOSCALER_CF_ORG: ((cf.development.org))
-#      AUTOSCALER_CF_SPACE: ((cf.development.space))
 
 ## Acceptance tests for dev
 
@@ -169,6 +111,9 @@ jobs:
     - get: release
       passed: [deploy-app-autoscaler-development]
       trigger: true
+    - get: autoscaler-acceptance
+      passed: [deploy-app-autoscaler-development]
+      trigger: true
   - task: acceptance-tests
     file: autoscaler-manifests/ci/acceptance-tests.yml
     params:
@@ -180,13 +125,13 @@ jobs:
       COMPONENT_TO_TEST: broker
       AUTOSCALER_CF_ORG: ((cf.development.org))
       AUTOSCALER_CF_SPACE: ((cf.development.space))
-  on_failure:
-    put: slack
-    params:
-      <<: *slack-failure-params
-      text: |
-        :x: FAILED testing the broker component of CF App Autoscaler on development
-        <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
+#  on_failure:
+#    put: slack
+#    params:
+#      <<: *slack-failure-params
+#      text: |
+#        :x: FAILED testing the broker component of CF App Autoscaler on development
+#        <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
 
 
 - name: acceptance-tests-api-development
@@ -197,6 +142,9 @@ jobs:
       trigger: true
       passed: [deploy-app-autoscaler-development]
     - get: release
+      passed: [deploy-app-autoscaler-development]
+      trigger: true
+    - get: autoscaler-acceptance
       passed: [deploy-app-autoscaler-development]
       trigger: true
   - task: acceptance-tests
@@ -210,13 +158,13 @@ jobs:
       COMPONENT_TO_TEST: api
       AUTOSCALER_CF_ORG: ((cf.development.org))
       AUTOSCALER_CF_SPACE: ((cf.development.space))
-  on_failure:
-    put: slack
-    params:
-      <<: *slack-failure-params
-      text: |
-        :x: FAILED testing the api component of CF App Autoscaler on development
-        <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
+#  on_failure:
+#    put: slack
+#    params:
+#      <<: *slack-failure-params
+#      text: |
+#        :x: FAILED testing the api component of CF App Autoscaler on development
+#        <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
 
 
 - name: acceptance-tests-app-development
@@ -227,6 +175,9 @@ jobs:
       trigger: true
       passed: [deploy-app-autoscaler-development]
     - get: release
+      passed: [deploy-app-autoscaler-development]
+      trigger: true
+    - get: autoscaler-acceptance
       passed: [deploy-app-autoscaler-development]
       trigger: true
   - task: acceptance-tests
@@ -240,13 +191,13 @@ jobs:
       COMPONENT_TO_TEST: app
       AUTOSCALER_CF_ORG: ((cf.development.org))
       AUTOSCALER_CF_SPACE: ((cf.development.space))
-  on_failure:
-    put: slack
-    params:
-      <<: *slack-failure-params
-      text: |
-        :x: FAILED testing the app component of CF App Autoscaler on development
-        <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
+#  on_failure:
+#    put: slack
+#    params:
+#      <<: *slack-failure-params
+#      text: |
+#        :x: FAILED testing the app component of CF App Autoscaler on development
+#        <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
 
 
 # Deploy Staging
@@ -347,6 +298,9 @@ jobs:
     - get: release
       passed: [deploy-app-autoscaler-staging]
       trigger: true
+    - get: autoscaler-acceptance
+      passed: [deploy-app-autoscaler-staging]
+      trigger: true
   - task: acceptance-tests
     file: autoscaler-manifests/ci/acceptance-tests.yml
     params:
@@ -376,6 +330,9 @@ jobs:
     - get: release
       passed: [deploy-app-autoscaler-staging]
       trigger: true
+    - get: autoscaler-acceptance
+      passed: [deploy-app-autoscaler-staging]
+      trigger: true
   - task: acceptance-tests
     file: autoscaler-manifests/ci/acceptance-tests.yml
     params:
@@ -403,6 +360,9 @@ jobs:
       trigger: true
       passed: [deploy-app-autoscaler-staging]
     - get: release
+      passed: [deploy-app-autoscaler-staging]
+      trigger: true
+    - get: autoscaler-acceptance
       passed: [deploy-app-autoscaler-staging]
       trigger: true
   - task: acceptance-tests
@@ -506,6 +466,9 @@ jobs:
     - get: release
       passed: [deploy-app-autoscaler-production]
       trigger: true
+    - get: autoscaler-acceptance
+      passed: [deploy-app-autoscaler-production]
+      trigger: true
   - task: acceptance-tests
     file: autoscaler-manifests/ci/acceptance-tests.yml
     params:
@@ -537,6 +500,9 @@ jobs:
     - get: release
       passed: [deploy-app-autoscaler-production]
       trigger: true
+    - get: autoscaler-acceptance
+      passed: [deploy-app-autoscaler-prod]
+      trigger: true
   - task: acceptance-tests
     file: autoscaler-manifests/ci/acceptance-tests.yml
     params:
@@ -566,6 +532,9 @@ jobs:
       trigger: true
       passed: [deploy-app-autoscaler-production]
     - get: release
+      passed: [deploy-app-autoscaler-production]
+      trigger: true
+    - get: autoscaler-acceptance
       passed: [deploy-app-autoscaler-production]
       trigger: true
   - task: acceptance-tests
@@ -601,10 +570,18 @@ resources:
   type: git
   source:
     uri: https://github.com/cloud-gov/cg-deploy-autoscaler.git
-    branch: main
+    branch: new-acceptance #main
     paths:
     - ci/*
     - bosh/*
+
+- name: autoscaler-acceptance     #Repo with acceptance tests
+  type: git
+  source:
+    uri: https://github.com/cloudfoundry/app-autoscaler
+    branch: main
+    tag_filter: "v*"
+
 
 - name: release                  #Used to detect when new bosh releases are cut
   type: github-release
@@ -612,15 +589,6 @@ resources:
     owner: cloudfoundry
     repository: app-autoscaler-release
     access_token: ((github-access-token))
-
-#- name: autoscaler-manifests-test
-#  type: git
-#  source:
-#    uri: https://github.com/cloud-gov/cg-deploy-autoscaler.git
-#    branch: main
-#    paths:
-#    - ci/*
-#    - bosh/*
 
 - name: pipeline-tasks
   type: git

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -21,6 +21,7 @@ jobs:
   plan:
   - in_parallel:
     - get: app-autoscaler-release
+    - get: autoscaler-acceptance
     - get: release
       trigger: true
     - get: autoscaler-manifests
@@ -210,6 +211,9 @@ jobs:
     - get: app-autoscaler-release
       passed: [deploy-app-autoscaler-development]
       trigger: true
+    - get: autoscaler-acceptance
+      passed: [deploy-app-autoscaler-development]
+      trigger: true
     - get: release
       passed: [deploy-app-autoscaler-development]
       trigger: true
@@ -394,6 +398,9 @@ jobs:
     - get: app-autoscaler-release
       passed: [deploy-app-autoscaler-staging]
       trigger: true
+    - get: autoscaler-acceptance
+      passed: [deploy-app-autoscaler-staging]
+      trigger: true
     - get: release
       passed: [deploy-app-autoscaler-staging]
       trigger: true
@@ -501,7 +508,7 @@ jobs:
       passed: [deploy-app-autoscaler-production]
       trigger: true
     - get: autoscaler-acceptance
-      passed: [deploy-app-autoscaler-prod]
+      passed: [deploy-app-autoscaler-production]
       trigger: true
   - task: acceptance-tests
     file: autoscaler-manifests/ci/acceptance-tests.yml


### PR DESCRIPTION
## Changes proposed in this pull request:

- Newer releases of app-autoscaler bosh release no longer include the acceptance tests tarball, this has moved to the underlying app-autoscaler repo
- The newer tests also no longer work off of _test.go files in api/app/broker folders, there are precompiled binaries with the tests build into them with a .test extension.  It still uses gingko inside of the binary so the duration and skip parameters (with a different syntax) still work and are needed.
- Removed on-failure slack notifications for tests in development. During debug they are noisy and unnecessary. 
- Part of https://github.com/cloud-gov/product/issues/2836

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None, no new secrets or changes to boundaries. 
